### PR TITLE
OCS Github Analytics Improvements; P1 Aadi, Derek, Rayhaan

### DIFF
--- a/_layouts/dashboard.html
+++ b/_layouts/dashboard.html
@@ -232,7 +232,6 @@ active_tab: Dashboard
             document.getElementById("username").textContent = `Username: ${username}`;
             document.getElementById("profile-url").innerHTML = `Profile URL: <a href="${profileUrl}" target="_blank" class="text-blue-400 hover:underline">${profileUrl}</a>`;
             document.getElementById("repos-url").innerHTML = `Repos URL: <a href="${reposUrl}" target="_blank" class="text-blue-400 hover:underline">${reposUrl}</a>`;
-            // Removed public repos link but kept number
             document.getElementById("public-repos").textContent = `Public Repos: ${userProfile.public_repos || 0}`;
             document.getElementById("public-gists").textContent = `Public Gists: ${userProfile.public_gists || 0}`;
             document.getElementById("followers").textContent = `Followers: ${userProfile.followers || 0}`;
@@ -273,7 +272,6 @@ active_tab: Dashboard
                 commitCardsContainer.appendChild(card);
             });
 
-            // Grade prediction buttons and output are moved to new tab, so disable them here
             const predictGradeBtn = document.getElementById("predictGradeBtn");
             const smartPredictBtn = document.getElementById("smartPredictBtn");
             const userGradeEl = document.getElementById("userGrade");
@@ -349,6 +347,8 @@ active_tab: Dashboard
             return '55% (F)';
         }
     }
+    
+    //Admin Feature commit cards rendering
     function renderCommitCards(commits, uid, container) {
         commits.slice(0, 15).forEach(commit => {
             const card = document.createElement("div");


### PR DESCRIPTION
We wanted to improve the Nighthawk Coders' portfolio webpage. When a user wants to see their analytics, it is undescriptive and sometimes inaccurate. Furthermore, the user is not able to click on their contributions on the frontend to view them. We will be adding these features so that the user can access their own profile through the Open Coding Society.

Changes made for first pull request:

- added cards to display recent user commits to different repositories, with links to the repos
- added total lines added/deleted in recent times to profile
- added grade predictor taking into account all contributions
- added admin feature to look up any user in the system's commit contributions

Changes made for second pull request:

- added analytics tab in submenu on the profile homepage
- this leads to the analytics page

Changes made for this (third) pull request:
- integrated github analytics into dashboard.html, styling formatted
- seperated admin search into another tab
- added description of grade predictor requirements