### PR TITLE
Penguins: Data abstraction lesson format change of frontmatter

### DIFF
--- a/_notebooks/CSSE/JavaScriptLessons/Data_Abstractions/2025-09-30-penguins-data-abstraction-lesson.ipynb
+++ b/_notebooks/CSSE/JavaScriptLessons/Data_Abstractions/2025-09-30-penguins-data-abstraction-lesson.ipynb
@@ -12,7 +12,10 @@
     "---\n",
     "layout: opencs\n",
     "title: Data Abstraction Lesson\n",
-    "permalink: /penguins/js-lessons/data-abstraction\n",
+    "permalink: /javascript/data-abstraction/penguins-lesson\n",
+    "description: Penguins group data abstraction lesson\n",
+    "category: [Javascript]\n",
+    "author: The Penguins\n",
     "---"
    ]
   },

--- a/_notebooks/CSSE/JavaScriptLessons/Data_Abstractions/2025-10-06-penguins-data-abstraction-hw.ipynb
+++ b/_notebooks/CSSE/JavaScriptLessons/Data_Abstractions/2025-10-06-penguins-data-abstraction-hw.ipynb
@@ -11,8 +11,11 @@
    "source": [
     "---\n",
     "layout: opencs\n",
-    "title: Data Abstraction Lesson\n",
-    "permalink: /penguins/js-lessons/homework/data-abstraction\n",
+    "title: Data Abstraction Homework\n",
+    "permalink: /javascript/data-abstraction/penguins-hw\n",
+    "description: Penguins group data abstraction lesson homework\n",
+    "category: [Javascript]\n",
+    "author: The Penguins\n",
     "---"
    ]
   },


### PR DESCRIPTION
Added the lesson and homework to the javascript category and fixed the title of the homework.