### PR TITLE
Add the CSA Lessons Homepage to the sprint 2 course table

### DIFF
--- a/navigation/csamainlessons.md
+++ b/navigation/csamainlessons.md
@@ -1,8 +1,10 @@
 ---
 layout: post 
-title: CSA Lesson HomePage
+title: CSA Lessons Homepage
 search_exclude: true
 permalink: /navigation/csa-lessons/
+courses: {'csa':  {'week': 6}}
+type: lesson
 ---
 
 


### PR DESCRIPTION
Reason for change: The CSA Lessons Homepage can now be accessed on the sprint 2 which is a common hub for accessing resources for the class