### PR TITLE
Fixed Perferences 

### DIFF
--- a/_layouts/dashboard.html
+++ b/_layouts/dashboard.html
@@ -601,6 +601,8 @@ score += gists * 0.5
         <br>
         See the full <a href="/dashboard/help/analytics" class="text-blue-400 underline hover:text-blue-200">Analytics Help page</a> for detailed docs and examples.
     </div>
+            </div>
+
             <!-- Preferences tab content -->
             <div id="tab-content-preferences" class="tab-content hidden px-6 py-4 text-neutral-200 max-w-5xl mx-auto">
                 <h2 class="text-xl font-semibold mb-2">Preferences</h2>


### PR DESCRIPTION
Summary
Fixed a critical bug where the Preferences tab content was not visible on the Dashboard page.

Root Cause
The Help tab content <div> was missing its closing </div> tag, which caused the Preferences section to be nested inside the Help section. Since the Help tab content is hidden by default, the Preferences content was also hidden inside it and could never be displayed. So I fixed it.

