### PR TITLE
docker ps command replaced with new command

### DIFF
--- a/_notebooks/CSP/big-ideas/big-idea-4/2024-12-03-aws-deployment.ipynb
+++ b/_notebooks/CSP/big-ideas/big-idea-4/2024-12-03-aws-deployment.ipynb
@@ -175,7 +175,7 @@
     "\n",
     "In AWS EC2 terminal;\n",
     "\n",
-    "1. Run `sudo lsof -iTCP:(insert port without parentheses) -sTCP:LISTEN -nP` review list and find a port number starting in 8--- that is not in use. Valid ports are between 1024-49150, but we are asking that you stick to 8---.\n",
+    "1. Run `sudo lsof -iTCP:8--- -sTCP:LISTEN -nP` review list and find a port number starting in 8--- that is not in use. Valid ports are between 1024-49150, but we are asking that you stick to 8---.\n",
     "\n",
     "### On localhost setup Docker files using VSCode\n",
     "\n",


### PR DESCRIPTION
The docker ps command was outdated and did not check for ports being used by root which led to unexpected errors. The new command "sudo lsof -iTCP:8306 -sTCP:LISTEN -nP" checks for the port over the root and other users which is better for checking for unused ports.