### PR TITLE
Align menus with calendar inputs

### DIFF
--- a/_includes/calendar.html
+++ b/_includes/calendar.html
@@ -1088,7 +1088,7 @@
       
       // Strategy: fetch all events, match by title, then delete by ID.
       // This is reliable because the backend's confirmed endpoint is
-      // DELETE /api/calendar/delete_event/{id}.
+      // DELETE /api/calendar/delete/{id}.
       try {
         const eventsResponse = await fetch(`${javaURI}/api/calendar/events`, fetchOptions);
         if (eventsResponse.status === 401 || eventsResponse.status === 403 || (eventsResponse.redirected && eventsResponse.url && eventsResponse.url.includes('/login'))) {
@@ -1109,7 +1109,7 @@
         } else {
           const deleteResults = await Promise.all(
             eventsToDelete.map(event =>
-              fetch(`${javaURI}/api/calendar/delete_event/${event.id}`, {
+              fetch(`${javaURI}/api/calendar/delete/${event.id}`, {
                 ...fetchOptions,
                 method: 'DELETE'
               }).then(res => res.ok ? 1 : 0).catch(() => 0)


### PR DESCRIPTION


## Summary

Redesigned the calendar to make Groups the central unit. Courses (CSA/CSP/CSSE) are now derived from groups, not hardcoded. Fixed API paths to match actual backend. Ensured `period` is always sent in payloads for backend validation.



## Changes — `navigation/calendar.md`

**Removed:**
- Hardcoded `csaButton`, `cspButton`, `csseButton`, `viewToggle` toolbar buttons
- `filterEventsByClass()`, `currentFilter`, `showAppointments` state
- `redirect: 'manual'` from fetch options

**Added:**
- `filterMode` state (`'my-groups'` default / `'all'`)
- `getUserGroupNames()` / `getUserCourses()` — derive from user's groups
- `filterEvents()` — filters by group membership + course match + breaks always shown
- `myGroupsButton` / `allButton` with active indicator
- Group required validation on add event
- `period` always derived from selected group's `.course` field

**Fixed API paths:**
- `update_event/{id}` → `edit/{id}`
- `delete_event/{id}` → `delete/{id}`

## Changes — `_includes/calendar.html`

- Fixed `delete_event/{id}` → `delete/{id}` in sprint remove
- Sprint sync still sends `period: courseName` — unchanged and working

## Filter Logic

```
My Groups: show if event.groupName in user's groups
           OR event.period matches user's course
           OR event has no group/course (personal)
           Breaks/holidays always shown

All: everything shown
```

## Period Derivation

Backend requires `period` non-empty on `PUT /api/calendar/edit/{id}`. Frontend now derives it from the selected group's course on both add and edit.

## No Regressions

- Sprint sync/remove from course pages still works
- Event CRUD hits correct endpoints
- Breaks, holidays, priorities, appointments, auth handling all unchanged
- Slack events with `period` field still match via course filter

