### PR TITLE
Restructure tools setup intro page

### DIFF
--- a/_posts/Foundation/B-tools_and_equipment/2025-04-15-tools_home.md
+++ b/_posts/Foundation/B-tools_and_equipment/2025-04-15-tools_home.md
@@ -20,8 +20,8 @@ canonical_id: tool-setup
 
 <div class="my-4">
  <ul class="list-disc list-inside space-y-1">
-  <li>Tracking progress is essential, start an Issue!</li>
-  <li>Don't skip steps! That will lead to problems down the road.</li>
+  <li>Tracking your progress and documenting your steps is important for learning and for debugging if something goes wrong.</li>
+  <li>In this case, we track our progress with Github issues. If you don't what issues are, <a target="_blank" href="https://docs.github.com/en/issues/tracking-your-work-with-issues/learning-about-issues/about-issues">learn here</a>.</li>
  </ul>
 </div>
 


### PR DESCRIPTION
These changes were made to the tools setup intro page, with a screenshot below of the page (w/ changes) I'm talking about:
<img width="1303" height="810" alt="image" src="https://github.com/user-attachments/assets/bc6f24f9-e09d-4974-b1ae-dacd0ea1ef48" />



Summary of changes:
1. I made it more clear that the images were meant to be clicked as when I was browsing the site, it took me a while to figure that out despite the existing hints the reading icon on the top right of the images. I only realized those icons were there after I accidentally hovered over the images, discovering they were to be clicked on.
2. I removed the extraneous track progress questions. They didn't really serve any purpose, and the blog had already said users should put their progress in issues, so I don't see why they would be doing it on the site.
3. The tools page mentions GitHub Issues, but students likely don't know what that is yet, so a link has been provided to help learn what it is. Perhaps in the future, we can make a simplified issue guide, though the one offered by GitHub seems pretty straightforward and begineer-oriented.