### PR TITLE
integrate AI A/B test engine SDK into head-custom template

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -68,4 +68,4 @@
 <script src="{{ site.baseurl }}/assets/js/keyboard-shortcuts.js" defer></script>
 
 <!-- AI A/B Test Engine SDK -->
-<script src="http://localhost:3000/sdk.js" data-project-id="cmne47x980000f6bh85n80j17"></script>
+<script src="https://ai-ab-test-engine.vercel.app/sdk.js" data-project-id="cmnfour780000f63gu69kg2v8"></script>


### PR DESCRIPTION
Adds the AI A/B Test Engine SDK to the site's global <head> via _includes/head-custom.html.

## What this does:
- Injects a lightweight JS SDK (sdk.js) on every page that communicates with the A/B Engine backend
- Performs deterministic, sticky variant assignment per anonymous user (hashed userId stored in localStorage)
- Applies DOM text mutations for active test variants without any server-side changes
- Tracks view and conversion events back to the engine's analytics API
- Activates a visual Admin Overlay when ?ab_admin=true is appended to any URL, allowing anyone to:
  - Click any element on the page to select it as a test target
  - Generate AI-written variant copy (powered by Groq / Llama 3.1) with one click
  - Launch a live 50/50 A/B test instantly

## Files changed
- _includes/head-custom.html — adds the <script> SDK tag