### PR TITLE
Correct positioning of avatar forge npc

### DIFF
--- a/_projects/cs-pathway-game/levels/GameLevelCsPath0Forge.js
+++ b/_projects/cs-pathway-game/levels/GameLevelCsPath0Forge.js
@@ -175,7 +175,7 @@ class GameLevelCsPath0Forge {
 
     const avatarGatekeeperPos = {
       x: width * 0.50,
-      y: height * 0.23,
+      y: height * 0.20,
     };
 
     const worldThemeGatekeeperPos = {


### PR DESCRIPTION
This is a minor change to the positioning of the avatar forge NPC so it doesn't block the town square sign.

Below is a before and after of changes for reference:

Before:
<img width="1314" height="828" alt="image" src="https://github.com/user-attachments/assets/97daf25c-5e4c-4d12-aafc-34e4886ef976" />

After:
<img width="1512" height="852" alt="image" src="https://github.com/user-attachments/assets/277391d0-0144-4df9-95db-e07c985875e0" />
