### PR TITLE
UESL capstone pitch page — before/after analysis, unified card, infographic cleanup

### DIFF
--- a/_data/uesl_infograph.yml
+++ b/_data/uesl_infograph.yml
@@ -6,6 +6,26 @@ Topics:
     image: "capstone/uesl_foundation.svg"
     link: "https://www.unifiedesl.com/foundation"
     alt: "Unified Esports League Foundation logo — shield with game controller"
+    subtitle: "Gaming for All — Inclusion Through Esports"
+    description: "A 501(c)(3) nonprofit (EIN: 88-2591302) dedicated to supporting individuals with intellectual and developmental disabilities. UESL provides esports competitions, multi-location gaming arenas, and structured career development pathways — giving participants meaningful connection, skill-building, and a path into the STEM and gaming workforce."
+    status: "Active 501(c)(3) Nonprofit"
+    team:
+      - "UESL Foundation Board of Directors"
+      - "San Diego & Imperial County Community Partners"
+
+    problems:
+      - "Individuals with intellectual and developmental disabilities lack structured, accessible social and career-development spaces outside the school calendar"
+      - "Mainstream esports and gaming environments are rarely designed for neurodiverse participants, creating exclusion in a growing industry"
+      - "Career and college pathways in STEM and gaming are almost never adapted for people with IDD, leaving a workforce pipeline gap"
+
+    ideas:
+      - title: "Skill & Career Progress Tracker"
+        description: "A digital portal where UESL participants log gaming milestones, STEM certifications, and career readiness checkpoints — making growth visible to families and employers"
+      - title: "Inclusive Tournament Platform"
+        description: "Built as a drag-and-drop Game Maker and accessible game engine with 8 IDD-specific modes — slow mode, single-button control, high-contrast, large sprites, guided mode, reduced motion, face tracking, and sound toggles — so every participant can compete regardless of ability"
+      - title: "Community Social Platform"
+        description: "Realized as a full social hub with microblog posts, replies, reactions, game leaderboards, and real-time co-op multiplayer rooms via WebSocket — keeping the UESL community connected and collaborating beyond in-person sessions"
+
     keyPoints:
       - "Serves San Diego & Imperial Counties year-round"
       - "Gaming arenas open independent of school calendars"
@@ -13,21 +33,29 @@ Topics:
       - "Builds communication, collaboration & problem-solving skills"
       - "Spanish-language programming for broader community access"
       - "Hosts Special Needs Super Smash Grand Championship events"
-    subtitle: "Gaming for All — Inclusion Through Esports"
-    description: "A 501(c)(3) nonprofit (EIN: 88-2591302) dedicated to supporting individuals with intellectual and developmental disabilities. UESL provides esports competitions, multi-location gaming arenas, and structured career development pathways — giving participants meaningful connection, skill-building, and a path into the STEM and gaming workforce."
+
     tech:
-      - "Esports Competitions"
-      - "Multi-Location Gaming Arenas"
-      - "STEM Career Pathways"
-      - "College Readiness Programs"
-      - "Community Enrichment Events"
-      - "Bilingual Outreach"
+      - name: "Esports Competitions"
+        solves: "Structured competitive play builds social skills and routine for IDD participants"
+      - name: "Multi-Location Gaming Arenas"
+        solves: "Accessible physical spaces remove barriers and provide consistent community hubs"
+      - name: "STEM Career Pathway Programs"
+        solves: "Adapted curriculum creates real workforce entry points in the gaming industry"
+      - name: "Bilingual Outreach Tools"
+        solves: "Spanish-language support ensures non-English-speaking families can participate"
+      - name: "Year-Round Scheduling Platform"
+        solves: "School-calendar-independent programming eliminates seasonal access gaps"
+
     impact:
       - "Year-round access to competitive gaming and social community"
       - "Structured career development into gaming & technology industries"
       - "Inclusive championship events celebrating diverse abilities"
       - "Bilingual support expanding reach across cultural communities"
       - "Multi-site arena presence across two California counties"
-    status: "Active 501(c)(3) Nonprofit"
-    team:
-      - "Rudra Darshan Sathwik"
+
+    weeklyIssues:
+      - "Deploy UESL Coach chatbot (Groq / LLaMA 3.3-70b) to production with full UESL context and bilingual support"
+      - "Add real-time co-op multiplayer rooms via Socket.IO to support inclusive tournament bracket play"
+      - "Improve face tracker calibration and sensitivity controls in the Game Maker accessibility settings"
+      - "Integrate UESL event calendar with live SDRC event data for the social platform"
+      - "Build per-level score leaderboards and surface them in the social platform feed"

--- a/_includes/uesl-infograph.html
+++ b/_includes/uesl-infograph.html
@@ -2,74 +2,35 @@
 
 <div class="uesl-infograph">
 
-  <!-- Header -->
-  <div class="uesl-header">
-    <div class="uesl-badge">Community Foundation Infographic</div>
-    <h1 class="uesl-title">{{ data.Title }}</h1>
-    <p class="uesl-description">{{ data.Description }}</p>
-  </div>
-
-  <!-- Cards -->
   {% for topic in data.Topics %}
-  <div class="uesl-card">
-    <div class="uesl-card-grid">
 
-      <!-- Left: Image & Status -->
-      <div class="uesl-visual">
-        <a href="{{ topic.link }}" class="uesl-image-link" target="_blank" rel="noopener noreferrer">
-          <img src="{{ site.baseurl }}/images/{{ topic.image }}"
-               alt="{{ topic.alt }}" class="uesl-image">
-          <div class="uesl-overlay">
-            <span>Visit Foundation ↗</span>
-          </div>
-        </a>
-        <div class="uesl-status">{{ topic.status }}</div>
-        <div class="uesl-team">
-          <span class="uesl-team-label">Operated By</span>
-          <span class="uesl-team-name">{{ topic.team | join: " · " }}</span>
-        </div>
+  <!-- ── Problems Being Solved ──────────────────────── -->
+  <div class="uesl-section-card">
+    <div class="uesl-section-label">Problems Being Solved</div>
+    <div class="uesl-problems-grid">
+      {% for problem in topic.problems %}
+      <div class="uesl-problem-item">
+        <span class="uesl-problem-num">0{{ forloop.index }}</span>
+        <p>{{ problem }}</p>
       </div>
-
-      <!-- Center: Key Points & Tech Tags -->
-      <div class="uesl-content">
-        <h2 class="uesl-project-title">{{ topic.title }}</h2>
-        <p class="uesl-subtitle">{{ topic.subtitle }}</p>
-
-        <div class="uesl-keypoints">
-          {% for point in topic.keyPoints %}
-          <div class="uesl-keypoint">
-            <span class="uesl-check">✓</span>
-            <span>{{ point }}</span>
-          </div>
-          {% endfor %}
-        </div>
-
-        <div class="uesl-tech-stack">
-          {% for tag in topic.tech %}
-          <span class="uesl-tech-tag">{{ tag }}</span>
-          {% endfor %}
-        </div>
-      </div>
-
-      <!-- Right: About & Impact -->
-      <div class="uesl-details">
-        <h3 class="uesl-section-title">About</h3>
-        <p class="uesl-about">{{ topic.description }}</p>
-
-        <h3 class="uesl-section-title">Impact</h3>
-        <div class="uesl-impact-list">
-          {% for item in topic.impact %}
-          <div class="uesl-impact-item">{{ item }}</div>
-          {% endfor %}
-        </div>
-
-        <a href="{{ topic.link }}" class="uesl-btn" target="_blank" rel="noopener noreferrer">
-          Learn More ↗
-        </a>
-      </div>
-
+      {% endfor %}
     </div>
   </div>
+
+  <!-- ── Key Tech That Solves Problems ──────────────── -->
+  <div class="uesl-section-card">
+    <div class="uesl-section-label">Key Tech &amp; How It Helps</div>
+    <div class="uesl-tech-table">
+      {% for t in topic.tech %}
+      <div class="uesl-tech-row">
+        <span class="uesl-tech-tag">{{ t.name }}</span>
+        <span class="uesl-tech-arrow">→</span>
+        <span class="uesl-tech-solve">{{ t.solves }}</span>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+
   {% endfor %}
 
 </div>

--- a/_posts/capstone/2026-02-09-capstone_home.md
+++ b/_posts/capstone/2026-02-09-capstone_home.md
@@ -378,8 +378,8 @@ Below are the capstone infographic pages created by student groups. Click an ima
            <img src="/images/capstone/pybl.png" alt="PYBL capstone preview image" class="w-28 h-28 object-cover rounded" />
        </a>
        <div>
-           <h3 class="text-lg font-semibold"><a href="{% post_url 2026-03-06-pybl-capstone %}">Poway Neighborhood Emergency Corps</a></h3>
-           <p class="text-sm text-gray-700">Upgraded Poway NEC website designed to provide valuable features to improve quality of life for the organization that include a login system, danger predictor, and AI chatbot.</p>
+           <h3 class="text-lg font-semibold"><a href="{% post_url 2026-03-06-pybl-capstone %}">Binary Beasts</a></h3>
+           <p class="text-sm text-gray-700">Combined PYBL + Poway NEC capstone infographics on one page: youth basketball operations and emergency preparedness information architecture improvements.</p>
            <p class="text-xs text-gray-500 mt-2">Team: Aneesh, Ethan, Samarth</p>
        </div>
    </div>
@@ -452,8 +452,8 @@ Below are the capstone infographic pages created by student groups. Click an ima
        </a>
        <div>
            <h3 class="text-lg font-semibold"><a href="{% post_url 2026-03-05-uesl-capstone %}">UESL Foundation</a></h3>
-           <p class="text-sm text-gray-700">Empowering individuals with intellectual and developmental disabilities through year-round esports and community programs across San Diego and Imperial Counties.</p>
-           <p class="text-xs text-gray-500 mt-2">Team: Rudra Darshan Sathwik</p>
+           <p class="text-sm text-gray-700">Built an AI chatbot, accessible game engine with 8 IDD-friendly modes, and a social platform to extend UESL's reach for individuals with intellectual and developmental disabilities across San Diego.</p>
+           <p class="text-xs text-gray-500 mt-2">Team: Sathwik Kintada, Rudra B Joshi, Darshan</p>
        </div>
    </div>
 
@@ -477,7 +477,7 @@ Below are the capstone infographic pages created by student groups. Click an ima
        <div>
            <h3 class="text-lg font-semibold"><a href="{% post_url 2026-03-08-sip-infograph %}">Soroptimist International of Poway</a></h3>
            <p class="text-sm text-gray-700">We analyzed sipoway.com to document the organization's programs and recommend UI improvements that help donors, volunteers, and program applicants take action.</p>
-           <p class="text-xs text-gray-500 mt-2">Team: Anishka Sanghvi, Michelle Ji, Krishna Visvanath, West Stefany</p>
+           <p class="text-xs text-gray-500 mt-2">Team: Anishka Sanghvi, Michelle Ji, Krishna Visvanath</p>
        </div>
    </div>
 

--- a/_posts/capstone/2026-03-05-uesl-capstone.md
+++ b/_posts/capstone/2026-03-05-uesl-capstone.md
@@ -1,10 +1,103 @@
 ---
 toc: false
 layout: post
-title: UESL Foundation Infographic
-description: Unified Esports League Foundation — a 501(c)(3) nonprofit empowering individuals with intellectual and developmental disabilities through esports, gaming arenas, and STEM career pathways across San Diego and Imperial Counties.
+title: UESL Foundation — CSP Capstone Project
+description: How our team built an AI chatbot, accessible game engine, and social platform to extend UESL's mission for individuals with intellectual and developmental disabilities across San Diego.
 permalink: /capstone/uesl/
 sticky_rank: 8
 ---
 
-{% include uesl-infograph.html %}
+<div style="background: linear-gradient(135deg, #0f0a1e 0%, #1a1033 100%); border-radius: 16px; padding: 2.5rem; margin-bottom: 2rem; border: 1px solid rgba(124,58,237,0.3);">
+
+  <!-- ── Header: Logo + Title + Team ── -->
+  <div style="display: flex; align-items: flex-start; gap: 2rem; flex-wrap: wrap; margin-bottom: 2rem;">
+
+    <div style="flex-shrink: 0; text-align: center;">
+      <img src="/images/capstone/uesl_foundation.svg" alt="UESL Foundation logo" style="width: 110px; height: 110px; display: block; margin-bottom: 0.6rem;">
+      <div style="background: rgba(124,58,237,0.25); border: 1px solid rgba(124,58,237,0.5); border-radius: 6px; padding: 0.2rem 0.6rem; font-size: 0.7rem; color: #a78bfa; text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap;">Active 501(c)(3)</div>
+    </div>
+
+    <div style="flex: 1; min-width: 240px;">
+      <div style="display: inline-block; background: rgba(124,58,237,0.2); border: 1px solid rgba(124,58,237,0.4); border-radius: 9999px; padding: 0.2rem 0.9rem; font-size: 0.7rem; color: #a78bfa; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 0.6rem;">CSP Capstone Project</div>
+      <h2 style="color: #f5f3ff; font-size: 1.6rem; font-weight: 700; margin: 0 0 0.3rem;">Building for UESL Foundation</h2>
+      <p style="color: #a78bfa; margin: 0 0 0.75rem; font-size: 0.9rem;">Sathwik Kintada &nbsp;·&nbsp; Rudra B Joshi &nbsp;·&nbsp; Darshan</p>
+      <p style="color: #c4b5fd; font-size: 0.9rem; line-height: 1.6; margin: 0 0 1rem;">We partnered with the Unified Esports League Foundation — a nonprofit serving individuals with intellectual and developmental disabilities through esports and STEM — to build digital tools that extend their reach beyond in-person sessions.</p>
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.3rem 1rem;">
+        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Serves San Diego &amp; Imperial Counties year-round</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Builds communication &amp; problem-solving skills</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Gaming arenas open independent of school calendars</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Spanish-language programming for broader access</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Career &amp; college pathways in STEM and gaming</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Hosts Special Needs Super Smash Grand Championship</div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ── Before / After Analysis ── -->
+  <div style="margin-bottom: 2rem;">
+    <div style="text-align: center; margin-bottom: 1rem;">
+      <span style="color: #a78bfa; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; font-weight: 600;">Current vs. Proposed Analysis</span>
+    </div>
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+
+      <!-- Before -->
+      <div style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.1); border-radius: 12px; padding: 1.25rem;">
+        <div style="display: inline-block; background: rgba(255,100,100,0.15); border: 1px solid rgba(255,100,100,0.3); border-radius: 9999px; padding: 0.15rem 0.75rem; font-size: 0.7rem; color: #fca5a5; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;">Before — Current State</div>
+        <h4 style="color: #f5f3ff; font-size: 0.95rem; font-weight: 700; margin: 0 0 0.5rem;">What UESL Has Today</h4>
+        <ul style="color: #c4b5fd; font-size: 0.82rem; line-height: 1.7; margin: 0 0 1rem; padding-left: 1.1rem;">
+          <li>Static foundation website with org information only</li>
+          <li>No interactive features or digital tools for participants</li>
+          <li>No way for the community to connect or engage online</li>
+          <li>No chatbot — visitors must call or email for program info</li>
+          <li>No playable games or accessible esports experience online</li>
+        </ul>
+        <a href="https://www.unifiedesl.com/foundation" target="_blank" rel="noopener noreferrer" style="display: inline-block; border: 1px solid rgba(255,255,255,0.2); color: #c4b5fd; font-size: 0.8rem; padding: 0.4rem 1rem; border-radius: 9999px; text-decoration: none;">View Current Site ↗</a>
+      </div>
+
+      <!-- After -->
+      <div style="background: rgba(124,58,237,0.1); border: 1px solid rgba(124,58,237,0.35); border-radius: 12px; padding: 1.25rem;">
+        <div style="display: inline-block; background: rgba(124,58,237,0.3); border: 1px solid rgba(124,58,237,0.5); border-radius: 9999px; padding: 0.15rem 0.75rem; font-size: 0.7rem; color: #a78bfa; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;">After — Our Proposal</div>
+        <h4 style="color: #f5f3ff; font-size: 0.95rem; font-weight: 700; margin: 0 0 0.5rem;">What We're Proposing</h4>
+        <ul style="color: #ddd6fe; font-size: 0.82rem; line-height: 1.7; margin: 0 0 1rem; padding-left: 1.1rem;">
+          <li>AI chatbot for instant program and eligibility questions</li>
+          <li>Playable game engine with 8 IDD-specific accessibility modes</li>
+          <li>Social platform for year-round community connection</li>
+          <li>Real-time multiplayer and leaderboards for inclusive competition</li>
+          <li>Event calendar keeping participants engaged beyond sessions</li>
+        </ul>
+        <a href="https://ueslhub.opencodingsociety.com" target="_blank" rel="noopener noreferrer" style="display: inline-block; background: linear-gradient(135deg, #7c3aed, #06b6d4); color: white; font-size: 0.8rem; font-weight: 700; padding: 0.4rem 1rem; border-radius: 9999px; text-decoration: none;">View Our Hub ↗</a>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ── 3 Feature Cards ── -->
+  <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1.25rem; margin-bottom: 2rem;">
+
+    <div style="background: rgba(124,58,237,0.12); border: 1px solid rgba(124,58,237,0.3); border-radius: 12px; padding: 1.25rem;">
+      <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🤖</div>
+      <h3 style="color: #a78bfa; font-size: 1rem; font-weight: 700; margin: 0 0 0.5rem;">UESL Coach Chatbot</h3>
+      <p style="color: #ddd6fe; font-size: 0.875rem; margin: 0; line-height: 1.6;">An AI assistant pre-loaded with UESL context that helps participants, families, and visitors navigate programs, locations, and eligibility — powered by Groq (LLaMA 3.3-70b) with a friendly, conversational style.</p>
+    </div>
+
+    <div style="background: rgba(6,182,212,0.08); border: 1px solid rgba(6,182,212,0.25); border-radius: 12px; padding: 1.25rem;">
+      <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🎮</div>
+      <h3 style="color: #67e8f9; font-size: 1rem; font-weight: 700; margin: 0 0 0.5rem;">Accessible Game Engine &amp; Maker</h3>
+      <p style="color: #ddd6fe; font-size: 0.875rem; margin: 0; line-height: 1.6;">A drag-and-drop level editor and playable game engine with 8 IDD-friendly accessibility modes: slow mode, single-button control, high-contrast, large sprites, guided mode, reduced motion, face tracking, and sound toggles.</p>
+    </div>
+
+    <div style="background: rgba(124,58,237,0.12); border: 1px solid rgba(124,58,237,0.3); border-radius: 12px; padding: 1.25rem;">
+      <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">💬</div>
+      <h3 style="color: #a78bfa; font-size: 1rem; font-weight: 700; margin: 0 0 0.5rem;">Social Platform</h3>
+      <p style="color: #ddd6fe; font-size: 0.875rem; margin: 0; line-height: 1.6;">A community hub with microblog posts, replies, reactions, game leaderboards, and real-time co-op multiplayer via WebSocket — keeping participants connected and competing year-round beyond in-person sessions.</p>
+    </div>
+
+  </div>
+
+  <!-- ── Why It Matters ── -->
+  <div style="background: rgba(255,255,255,0.04); border-left: 3px solid #7c3aed; border-radius: 0 8px 8px 0; padding: 1rem 1.25rem;">
+    <p style="color: #e9d5ff; font-size: 0.9rem; margin: 0; line-height: 1.7;">UESL serves 100+ individuals with IDD across 7 tech centers in San Diego and Imperial Counties — but their reach is limited to in-person sessions. These three tools extend that reach digitally: the chatbot lowers the barrier to entry, the game engine makes competitive esports playable for every ability level, and the social platform keeps the community connected year-round.</p>
+  </div>
+
+</div>


### PR DESCRIPTION
## Summary
- Rewrites the UESL capstone page (`/capstone/uesl/`) as a project pitch with a unified top card
- Adds a **Before / After Analysis** section linking to UESL's current site vs. our hub at `ueslhub.opencodingsociety.com`
- Removes redundant infographic sections (duplicate header, info card, Top 3 Ideas, Individual Issues)
- Updates the capstone home card description and team credit (Sathwik Kintada, Rudra B Joshi, Darshan)
- Updates `uesl_infograph.yml` weeklyIssues to reflect active development work

## Test plan
- [ ] Navigate to `/capstone/uesl/` — confirm unified pitch card with logo, team byline, key points, and before/after comparison renders correctly
- [ ] Confirm "View Current Site" links to `unifiedesl.com/foundation` and "View Our Hub" links to `ueslhub.opencodingsociety.com`
- [ ] Navigate to `/capstone/` — confirm UESL card shows updated description and student team names

🤖 Generated with [Claude Code](https://claude.com/claude-code)