### PR TITLE
UESL capstone: inline extended info dropdown

### DIFF
--- a/_posts/capstone/2026-03-05-uesl-capstone.md
+++ b/_posts/capstone/2026-03-05-uesl-capstone.md
@@ -9,7 +9,7 @@ sticky_rank: 8
 
 <div style="background: linear-gradient(135deg, #0f0a1e 0%, #1a1033 100%); border-radius: 16px; padding: 2.5rem; margin-bottom: 2rem; border: 1px solid rgba(124,58,237,0.3);">
 
-  <!-- ── Header: Logo + Title + Team ── -->
+  <!-- Header -->
   <div style="display: flex; align-items: flex-start; gap: 2rem; flex-wrap: wrap; margin-bottom: 2rem;">
 
     <div style="flex-shrink: 0; text-align: center;">
@@ -21,83 +21,224 @@ sticky_rank: 8
       <div style="display: inline-block; background: rgba(124,58,237,0.2); border: 1px solid rgba(124,58,237,0.4); border-radius: 9999px; padding: 0.2rem 0.9rem; font-size: 0.7rem; color: #a78bfa; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 0.6rem;">CSP Capstone Project</div>
       <h2 style="color: #f5f3ff; font-size: 1.6rem; font-weight: 700; margin: 0 0 0.3rem;">Building for UESL Foundation</h2>
       <p style="color: #a78bfa; margin: 0 0 0.75rem; font-size: 0.9rem;">Sathwik Kintada &nbsp;·&nbsp; Rudra B Joshi &nbsp;·&nbsp; Darshan</p>
-      <p style="color: #c4b5fd; font-size: 0.9rem; line-height: 1.6; margin: 0 0 1rem;">We partnered with the Unified Esports League Foundation — a nonprofit serving individuals with intellectual and developmental disabilities through esports and STEM — to build digital tools that extend their reach beyond in-person sessions.</p>
+      <p style="color: #c4b5fd; font-size: 0.9rem; line-height: 1.6; margin: 0 0 1rem;">We partnered with the Unified Esports League Foundation — a 501(c)(3) nonprofit serving individuals with intellectual and developmental disabilities — to build an integrated digital platform that extends their mission beyond in-person programming across San Diego and Imperial Counties.</p>
       <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.3rem 1rem;">
-        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Serves San Diego &amp; Imperial Counties year-round</div>
-        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Builds communication &amp; problem-solving skills</div>
-        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Gaming arenas open independent of school calendars</div>
-        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Spanish-language programming for broader access</div>
-        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Career &amp; college pathways in STEM and gaming</div>
-        <div style="color: #ddd6fe; font-size: 0.8rem;">✓ Hosts Special Needs Super Smash Grand Championship</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">Serves San Diego &amp; Imperial Counties year-round</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">Career &amp; college pathways in STEM and gaming</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">Gaming arenas open independent of school calendars</div>
+        <div style="color: #ddd6fe; font-size: 0.8rem;">Spanish-language programming for broader access</div>
       </div>
     </div>
 
   </div>
 
-  <!-- ── Before / After Analysis ── -->
+  <!-- Current vs. Proposed -->
   <div style="margin-bottom: 2rem;">
     <div style="text-align: center; margin-bottom: 1rem;">
-      <span style="color: #a78bfa; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; font-weight: 600;">Current vs. Proposed Analysis</span>
+      <span style="color: #a78bfa; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; font-weight: 600;">Current vs. Proposed</span>
     </div>
     <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
 
-      <!-- Before -->
-      <div style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.1); border-radius: 12px; padding: 1.25rem;">
-        <div style="display: inline-block; background: rgba(255,100,100,0.15); border: 1px solid rgba(255,100,100,0.3); border-radius: 9999px; padding: 0.15rem 0.75rem; font-size: 0.7rem; color: #fca5a5; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;">Before — Current State</div>
-        <h4 style="color: #f5f3ff; font-size: 0.95rem; font-weight: 700; margin: 0 0 0.5rem;">What UESL Has Today</h4>
-        <ul style="color: #c4b5fd; font-size: 0.82rem; line-height: 1.7; margin: 0 0 1rem; padding-left: 1.1rem;">
-          <li>Static foundation website with org information only</li>
-          <li>No interactive features or digital tools for participants</li>
-          <li>No way for the community to connect or engage online</li>
-          <li>No chatbot — visitors must call or email for program info</li>
-          <li>No playable games or accessible esports experience online</li>
+      <div style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,100,100,0.2); border-radius: 12px; padding: 1.25rem;">
+        <div style="display: inline-block; background: rgba(255,100,100,0.15); border: 1px solid rgba(255,100,100,0.3); border-radius: 9999px; padding: 0.15rem 0.75rem; font-size: 0.7rem; color: #fca5a5; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;">Current State</div>
+        <ul style="color: #c4b5fd; font-size: 0.82rem; line-height: 1.75; margin: 0 0 0.75rem; padding-left: 1.1rem;">
+          <li>Static website — no interactive features for participants</li>
+          <li>Program inquiries require phone or email; 24–72 hr response gap</li>
+          <li>No online games — participation locked to physical arenas</li>
+          <li>Community dissolves between sessions with no persistent space</li>
         </ul>
-        <a href="https://www.unifiedesl.com/foundation" target="_blank" rel="noopener noreferrer" style="display: inline-block; border: 1px solid rgba(255,255,255,0.2); color: #c4b5fd; font-size: 0.8rem; padding: 0.4rem 1rem; border-radius: 9999px; text-decoration: none;">View Current Site ↗</a>
+        <div style="background: rgba(255,100,100,0.07); border-radius: 6px; padding: 0.6rem 0.9rem; margin-bottom: 0.75rem;">
+          <div style="color: #fca5a5; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 0.25rem;">Consequence</div>
+          <div style="color: #c4b5fd; font-size: 0.78rem; line-height: 1.55;">UESL's reach is capped by venue capacity. Spanish-speaking families cannot navigate programs without staff support. Participants disengage between seasons with no digital touchpoint.</div>
+        </div>
+        <a href="https://www.unifiedesl.com/foundation" target="_blank" rel="noopener noreferrer" style="display: inline-block; border: 1px solid rgba(255,255,255,0.2); color: #c4b5fd; font-size: 0.8rem; padding: 0.4rem 1rem; border-radius: 9999px; text-decoration: none;">View Current Site</a>
       </div>
 
-      <!-- After -->
       <div style="background: rgba(124,58,237,0.1); border: 1px solid rgba(124,58,237,0.35); border-radius: 12px; padding: 1.25rem;">
-        <div style="display: inline-block; background: rgba(124,58,237,0.3); border: 1px solid rgba(124,58,237,0.5); border-radius: 9999px; padding: 0.15rem 0.75rem; font-size: 0.7rem; color: #a78bfa; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;">After — Our Proposal</div>
-        <h4 style="color: #f5f3ff; font-size: 0.95rem; font-weight: 700; margin: 0 0 0.5rem;">What We're Proposing</h4>
-        <ul style="color: #ddd6fe; font-size: 0.82rem; line-height: 1.7; margin: 0 0 1rem; padding-left: 1.1rem;">
-          <li>AI chatbot for instant program and eligibility questions</li>
-          <li>Playable game engine with 8 IDD-specific accessibility modes</li>
-          <li>Social platform for year-round community connection</li>
-          <li>Real-time multiplayer and leaderboards for inclusive competition</li>
-          <li>Event calendar keeping participants engaged beyond sessions</li>
+        <div style="display: inline-block; background: rgba(124,58,237,0.3); border: 1px solid rgba(124,58,237,0.5); border-radius: 9999px; padding: 0.15rem 0.75rem; font-size: 0.7rem; color: #a78bfa; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;">Our Platform</div>
+        <ul style="color: #ddd6fe; font-size: 0.82rem; line-height: 1.75; margin: 0 0 0.75rem; padding-left: 1.1rem;">
+          <li>AI chatbot answers program questions instantly, 24/7, in English and Spanish</li>
+          <li>Game engine with 8 IDD-specific accessibility modes — playable from any device</li>
+          <li>Social platform keeping participants connected and competing year-round</li>
+          <li>Real-time multiplayer and leaderboards for inclusive online competition</li>
         </ul>
-        <a href="https://ueslhub.opencodingsociety.com" target="_blank" rel="noopener noreferrer" style="display: inline-block; background: linear-gradient(135deg, #7c3aed, #06b6d4); color: white; font-size: 0.8rem; font-weight: 700; padding: 0.4rem 1rem; border-radius: 9999px; text-decoration: none;">View Our Hub ↗</a>
+        <div style="background: rgba(124,58,237,0.1); border-radius: 6px; padding: 0.6rem 0.9rem; margin-bottom: 0.75rem;">
+          <div style="color: #a78bfa; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 0.25rem;">Outcome</div>
+          <div style="color: #c4b5fd; font-size: 0.78rem; line-height: 1.55;">UESL's reach is no longer limited by venue or staff. Families self-serve in their language. Participants stay engaged 365 days a year through gameplay and community.</div>
+        </div>
+        <a href="https://ueslhub.opencodingsociety.com" target="_blank" rel="noopener noreferrer" style="display: inline-block; background: linear-gradient(135deg, #7c3aed, #06b6d4); color: white; font-size: 0.8rem; font-weight: 700; padding: 0.4rem 1rem; border-radius: 9999px; text-decoration: none;">View Our Hub</a>
       </div>
 
     </div>
   </div>
 
-  <!-- ── 3 Feature Cards ── -->
-  <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1.25rem; margin-bottom: 2rem;">
+  <!-- Extended Info Dropdown -->
+  <details style="margin-bottom: 2rem;">
+    <summary style="display: flex; align-items: center; justify-content: center; gap: 0.6rem; background: rgba(124,58,237,0.15); border: 1px solid rgba(124,58,237,0.4); border-radius: 9999px; padding: 0.65rem 2rem; color: #a78bfa; font-size: 0.9rem; font-weight: 600; letter-spacing: 0.03em; cursor: pointer; list-style: none; width: fit-content; margin: 0 auto;">
+      <span>Extended Information</span>
+      <span style="font-size: 0.75rem; transition: transform 0.2s;">▼</span>
+    </summary>
 
-    <div style="background: rgba(124,58,237,0.12); border: 1px solid rgba(124,58,237,0.3); border-radius: 12px; padding: 1.25rem;">
-      <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🤖</div>
-      <h3 style="color: #a78bfa; font-size: 1rem; font-weight: 700; margin: 0 0 0.5rem;">UESL Coach Chatbot</h3>
-      <p style="color: #ddd6fe; font-size: 0.875rem; margin: 0; line-height: 1.6;">An AI assistant pre-loaded with UESL context that helps participants, families, and visitors navigate programs, locations, and eligibility — powered by Groq (LLaMA 3.3-70b) with a friendly, conversational style.</p>
+    <div style="margin-top: 1.25rem; border: 1px solid rgba(124,58,237,0.2); border-radius: 12px; padding: 1.75rem; background: rgba(124,58,237,0.04);">
+
+      <!-- Component 01: Chatbot -->
+      <div style="margin-bottom: 2rem;">
+        <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem;">
+          <div style="background: rgba(124,58,237,0.25); border: 1px solid rgba(124,58,237,0.5); border-radius: 8px; padding: 0.3rem 0.7rem; font-size: 0.7rem; color: #a78bfa; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap;">Component 01</div>
+          <h3 style="color: #f5f3ff; font-size: 1.05rem; font-weight: 700; margin: 0;">UESL Coach — AI Chatbot</h3>
+        </div>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+          <div style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,100,100,0.2); border-radius: 12px; padding: 1.1rem;">
+            <div style="color: #fca5a5; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.6rem;">Current Site</div>
+            <ul style="color: #c4b5fd; font-size: 0.82rem; line-height: 1.75; margin: 0; padding-left: 1.1rem;">
+              <li>No chatbot — users must call or email staff</li>
+              <li>24–72 hour response gap for basic questions</li>
+              <li>No support outside business hours</li>
+              <li>English-only communication channels</li>
+              <li>High drop-off for families unfamiliar with the org</li>
+            </ul>
+          </div>
+          <div style="background: rgba(124,58,237,0.08); border: 1px solid rgba(124,58,237,0.3); border-radius: 12px; padding: 1.1rem;">
+            <div style="color: #a78bfa; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.6rem;">Our Platform</div>
+            <ul style="color: #ddd6fe; font-size: 0.82rem; line-height: 1.75; margin: 0; padding-left: 1.1rem;">
+              <li>Powered by Groq (LLaMA 3.3-70b), pre-loaded with full UESL context</li>
+              <li>Instant answers to program, eligibility, location, and scheduling questions</li>
+              <li>Available 24/7 — no staff required for common inquiries</li>
+              <li>Bilingual support in English and Spanish</li>
+              <li>Conversational tone designed for IDD participants and their families</li>
+            </ul>
+          </div>
+        </div>
+        <div style="background: rgba(124,58,237,0.07); border-left: 3px solid #7c3aed; border-radius: 0 8px 8px 0; padding: 0.75rem 1rem; margin-top: 0.75rem;">
+          <span style="color: #a78bfa; font-size: 0.75rem; font-weight: 700;">Why it matters: </span>
+          <span style="color: #c4b5fd; font-size: 0.82rem;">For families navigating IDD services, a 48-hour wait for a basic answer is a barrier that ends participation before it begins. The chatbot removes that barrier entirely.</span>
+        </div>
+      </div>
+
+      <!-- Component 02: Game Engine -->
+      <div style="margin-bottom: 2rem;">
+        <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem;">
+          <div style="background: rgba(6,182,212,0.15); border: 1px solid rgba(6,182,212,0.4); border-radius: 8px; padding: 0.3rem 0.7rem; font-size: 0.7rem; color: #67e8f9; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap;">Component 02</div>
+          <h3 style="color: #f5f3ff; font-size: 1.05rem; font-weight: 700; margin: 0;">Accessible Game Engine &amp; Maker</h3>
+        </div>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 0.75rem;">
+          <div style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,100,100,0.2); border-radius: 12px; padding: 1.1rem;">
+            <div style="color: #fca5a5; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.6rem;">Current Site</div>
+            <ul style="color: #c4b5fd; font-size: 0.82rem; line-height: 1.75; margin: 0; padding-left: 1.1rem;">
+              <li>No playable games of any kind online</li>
+              <li>Esports participation requires physical attendance at an arena</li>
+              <li>No accessibility accommodations for online play</li>
+              <li>Participants cannot create or share their own games</li>
+            </ul>
+          </div>
+          <div style="background: rgba(6,182,212,0.06); border: 1px solid rgba(6,182,212,0.25); border-radius: 12px; padding: 1.1rem;">
+            <div style="color: #67e8f9; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.6rem;">Our Platform</div>
+            <ul style="color: #ddd6fe; font-size: 0.82rem; line-height: 1.75; margin: 0; padding-left: 1.1rem;">
+              <li>Fully playable game engine accessible from any browser</li>
+              <li>Drag-and-drop Game Maker — participants build their own levels</li>
+              <li>8 IDD-specific accessibility modes built into the engine</li>
+              <li>Designed from the ground up for neurodiverse players — not adapted after the fact</li>
+            </ul>
+          </div>
+        </div>
+        <div style="background: rgba(6,182,212,0.05); border: 1px solid rgba(6,182,212,0.2); border-radius: 12px; padding: 1.1rem; margin-bottom: 0.75rem;">
+          <div style="color: #67e8f9; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;">8 Accessibility Modes — Built In</div>
+          <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.5rem;">
+            <div style="background: rgba(6,182,212,0.08); border-radius: 8px; padding: 0.5rem 0.75rem;"><div style="color: #f5f3ff; font-size: 0.8rem; font-weight: 600;">Slow Mode</div><div style="color: #94a3b8; font-size: 0.73rem;">Reduces game speed for motor processing differences</div></div>
+            <div style="background: rgba(6,182,212,0.08); border-radius: 8px; padding: 0.5rem 0.75rem;"><div style="color: #f5f3ff; font-size: 0.8rem; font-weight: 600;">Single-Button Control</div><div style="color: #94a3b8; font-size: 0.73rem;">Full gameplay with one input for limited mobility</div></div>
+            <div style="background: rgba(6,182,212,0.08); border-radius: 8px; padding: 0.5rem 0.75rem;"><div style="color: #f5f3ff; font-size: 0.8rem; font-weight: 600;">High Contrast</div><div style="color: #94a3b8; font-size: 0.73rem;">Enhanced visual clarity for low vision players</div></div>
+            <div style="background: rgba(6,182,212,0.08); border-radius: 8px; padding: 0.5rem 0.75rem;"><div style="color: #f5f3ff; font-size: 0.8rem; font-weight: 600;">Large Sprites</div><div style="color: #94a3b8; font-size: 0.73rem;">Scaled-up game elements for visibility</div></div>
+            <div style="background: rgba(6,182,212,0.08); border-radius: 8px; padding: 0.5rem 0.75rem;"><div style="color: #f5f3ff; font-size: 0.8rem; font-weight: 600;">Guided Mode</div><div style="color: #94a3b8; font-size: 0.73rem;">On-screen prompts and hints during gameplay</div></div>
+            <div style="background: rgba(6,182,212,0.08); border-radius: 8px; padding: 0.5rem 0.75rem;"><div style="color: #f5f3ff; font-size: 0.8rem; font-weight: 600;">Reduced Motion</div><div style="color: #94a3b8; font-size: 0.73rem;">Limits animations for sensory sensitivities</div></div>
+            <div style="background: rgba(6,182,212,0.08); border-radius: 8px; padding: 0.5rem 0.75rem;"><div style="color: #f5f3ff; font-size: 0.8rem; font-weight: 600;">Face Tracking</div><div style="color: #94a3b8; font-size: 0.73rem;">Camera-based input as an alternative controller</div></div>
+            <div style="background: rgba(6,182,212,0.08); border-radius: 8px; padding: 0.5rem 0.75rem;"><div style="color: #f5f3ff; font-size: 0.8rem; font-weight: 600;">Audio Toggles</div><div style="color: #94a3b8; font-size: 0.73rem;">Independent SFX and music controls</div></div>
+          </div>
+        </div>
+        <div style="background: rgba(6,182,212,0.05); border-left: 3px solid #06b6d4; border-radius: 0 8px 8px 0; padding: 0.75rem 1rem;">
+          <span style="color: #67e8f9; font-size: 0.75rem; font-weight: 700;">Why it matters: </span>
+          <span style="color: #c4b5fd; font-size: 0.82rem;">No mainstream game engine ships with IDD-specific modes. Ours was designed with those needs as the baseline — not bolted on. That distinction determines whether a participant can play at all.</span>
+        </div>
+      </div>
+
+      <!-- Component 03: Social Platform -->
+      <div style="margin-bottom: 2rem;">
+        <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem;">
+          <div style="background: rgba(124,58,237,0.25); border: 1px solid rgba(124,58,237,0.5); border-radius: 8px; padding: 0.3rem 0.7rem; font-size: 0.7rem; color: #a78bfa; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; white-space: nowrap;">Component 03</div>
+          <h3 style="color: #f5f3ff; font-size: 1.05rem; font-weight: 700; margin: 0;">Community Hub — Social Platform</h3>
+        </div>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+          <div style="background: rgba(255,255,255,0.03); border: 1px solid rgba(255,100,100,0.2); border-radius: 12px; padding: 1.1rem;">
+            <div style="color: #fca5a5; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.6rem;">Current Site</div>
+            <ul style="color: #c4b5fd; font-size: 0.82rem; line-height: 1.75; margin: 0; padding-left: 1.1rem;">
+              <li>No online community space of any kind</li>
+              <li>Participant relationships exist only during in-person sessions</li>
+              <li>No leaderboards, scores, or competitive tracking online</li>
+              <li>No multiplayer — competition requires physical co-location</li>
+              <li>Community engagement drops to zero between events</li>
+            </ul>
+          </div>
+          <div style="background: rgba(124,58,237,0.08); border: 1px solid rgba(124,58,237,0.3); border-radius: 12px; padding: 1.1rem;">
+            <div style="color: #a78bfa; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.6rem;">Our Platform</div>
+            <ul style="color: #ddd6fe; font-size: 0.82rem; line-height: 1.75; margin: 0; padding-left: 1.1rem;">
+              <li>Microblog feed — participants post, reply, and react</li>
+              <li>Per-level leaderboards surfaced directly in the social feed</li>
+              <li>Real-time co-op multiplayer rooms via WebSocket</li>
+              <li>Persistent profiles that track game progress and community activity</li>
+              <li>Year-round engagement independent of scheduled sessions</li>
+            </ul>
+          </div>
+        </div>
+        <div style="background: rgba(124,58,237,0.07); border-left: 3px solid #7c3aed; border-radius: 0 8px 8px 0; padding: 0.75rem 1rem; margin-top: 0.75rem;">
+          <span style="color: #a78bfa; font-size: 0.75rem; font-weight: 700;">Why it matters: </span>
+          <span style="color: #c4b5fd; font-size: 0.82rem;">Social connection is core to UESL's mission — but currently that connection only exists when participants are physically in the same room. The community hub makes it permanent and distance-independent.</span>
+        </div>
+      </div>
+
+      <!-- Platform Summary -->
+      <div style="background: rgba(255,255,255,0.04); border: 1px solid rgba(124,58,237,0.25); border-radius: 12px; padding: 1.25rem;">
+        <div style="color: #a78bfa; font-size: 0.72rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.75rem;">Platform Summary</div>
+        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; text-align: center;">
+          <div>
+            <div style="color: #f5f3ff; font-size: 1.4rem; font-weight: 700;">24/7</div>
+            <div style="color: #c4b5fd; font-size: 0.75rem; margin-top: 0.2rem;">Program support via chatbot vs. business-hours-only staff</div>
+          </div>
+          <div>
+            <div style="color: #f5f3ff; font-size: 1.4rem; font-weight: 700;">8 modes</div>
+            <div style="color: #c4b5fd; font-size: 0.75rem; margin-top: 0.2rem;">IDD-specific accessibility vs. zero accommodations online</div>
+          </div>
+          <div>
+            <div style="color: #f5f3ff; font-size: 1.4rem; font-weight: 700;">365 days</div>
+            <div style="color: #c4b5fd; font-size: 0.75rem; margin-top: 0.2rem;">Community engagement vs. in-person sessions only</div>
+          </div>
+        </div>
+      </div>
+
     </div>
+  </details>
 
-    <div style="background: rgba(6,182,212,0.08); border: 1px solid rgba(6,182,212,0.25); border-radius: 12px; padding: 1.25rem;">
-      <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">🎮</div>
-      <h3 style="color: #67e8f9; font-size: 1rem; font-weight: 700; margin: 0 0 0.5rem;">Accessible Game Engine &amp; Maker</h3>
-      <p style="color: #ddd6fe; font-size: 0.875rem; margin: 0; line-height: 1.6;">A drag-and-drop level editor and playable game engine with 8 IDD-friendly accessibility modes: slow mode, single-button control, high-contrast, large sprites, guided mode, reduced motion, face tracking, and sound toggles.</p>
+  <!-- Impact Metrics -->
+  <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.75rem; margin-bottom: 2rem;">
+    <div style="background: rgba(124,58,237,0.1); border: 1px solid rgba(124,58,237,0.3); border-radius: 10px; padding: 1rem; text-align: center;">
+      <div style="color: #f5f3ff; font-size: 1.6rem; font-weight: 700; line-height: 1;">80%+</div>
+      <div style="color: #c4b5fd; font-size: 0.72rem; line-height: 1.4; margin-top: 0.3rem;">Inquiries resolved by chatbot without staff</div>
     </div>
-
-    <div style="background: rgba(124,58,237,0.12); border: 1px solid rgba(124,58,237,0.3); border-radius: 12px; padding: 1.25rem;">
-      <div style="font-size: 1.5rem; margin-bottom: 0.5rem;">💬</div>
-      <h3 style="color: #a78bfa; font-size: 1rem; font-weight: 700; margin: 0 0 0.5rem;">Social Platform</h3>
-      <p style="color: #ddd6fe; font-size: 0.875rem; margin: 0; line-height: 1.6;">A community hub with microblog posts, replies, reactions, game leaderboards, and real-time co-op multiplayer via WebSocket — keeping participants connected and competing year-round beyond in-person sessions.</p>
+    <div style="background: rgba(6,182,212,0.08); border: 1px solid rgba(6,182,212,0.25); border-radius: 10px; padding: 1rem; text-align: center;">
+      <div style="color: #f5f3ff; font-size: 1.6rem; font-weight: 700; line-height: 1;">8</div>
+      <div style="color: #c4b5fd; font-size: 0.72rem; line-height: 1.4; margin-top: 0.3rem;">IDD-specific accessibility modes</div>
     </div>
-
+    <div style="background: rgba(124,58,237,0.1); border: 1px solid rgba(124,58,237,0.3); border-radius: 10px; padding: 1rem; text-align: center;">
+      <div style="color: #f5f3ff; font-size: 1.6rem; font-weight: 700; line-height: 1;">365</div>
+      <div style="color: #c4b5fd; font-size: 0.72rem; line-height: 1.4; margin-top: 0.3rem;">Days of digital community vs. seasonal sessions</div>
+    </div>
+    <div style="background: rgba(124,58,237,0.1); border: 1px solid rgba(124,58,237,0.3); border-radius: 10px; padding: 1rem; text-align: center;">
+      <div style="color: #f5f3ff; font-size: 1.1rem; font-weight: 700; line-height: 1.2;">Group Chats</div>
+      <div style="color: #c4b5fd; font-size: 0.72rem; line-height: 1.4; margin-top: 0.3rem;">Users can socialize through group chats</div>
+    </div>
   </div>
 
-  <!-- ── Why It Matters ── -->
+  <!-- Closing -->
   <div style="background: rgba(255,255,255,0.04); border-left: 3px solid #7c3aed; border-radius: 0 8px 8px 0; padding: 1rem 1.25rem;">
-    <p style="color: #e9d5ff; font-size: 0.9rem; margin: 0; line-height: 1.7;">UESL serves 100+ individuals with IDD across 7 tech centers in San Diego and Imperial Counties — but their reach is limited to in-person sessions. These three tools extend that reach digitally: the chatbot lowers the barrier to entry, the game engine makes competitive esports playable for every ability level, and the social platform keeps the community connected year-round.</p>
+    <p style="color: #e9d5ff; font-size: 0.9rem; margin: 0; line-height: 1.7;">The three components are one connected system — users onboard through the chatbot, engage through gameplay, and stay through community. Together they remove the ceiling on UESL's impact: no venue limits, no language barriers, no off-season disengagement.</p>
   </div>
 
 </div>


### PR DESCRIPTION
## Summary

- Converts the "Extended Information" button from a separate-page link to a native `<details>` accordion that expands inline on the same page
- Embeds all three component deep-dives (AI chatbot, accessible game engine, social platform) + platform summary directly on `/capstone/uesl/`
- Updates 4th stat card to "Group Chats" per Darshan's update

## Test plan

- [ ] Visit `/capstone/uesl/` — "Extended Information" button renders as a pill toggle
- [ ] Click it — content expands downward, no page navigation
- [ ] All three component sections (Component 01/02/03) display correctly
- [ ] 8 accessibility modes grid shows inside the game engine section

🤖 Generated with [Claude Code](https://claude.com/claude-code)