### PR TITLE
Change loading animation when AI NPC is thinking

### DIFF
--- a/_projects/cs-pathway-game/levels/GameLevelCsPath2Mission.js
+++ b/_projects/cs-pathway-game/levels/GameLevelCsPath2Mission.js
@@ -287,6 +287,9 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
     this._missionCompletedStations = new Set();
     this._missionProgressCount = 0;
     this._handleMissionDeskKeyDownBound = this._handleMissionDeskKeyDown.bind(this);
+    this._aiLoadingPending = 0;
+    this._aiLoadingToastTimer = null;
+    this._aiLoadingFrame = 0;
   }
 
   /**
@@ -362,16 +365,49 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
   }
 
   /**
-   * Wrap with loading. Brackets any async task with the level spinner lifecycle.
+   * Wrap with loading. Uses in-world toast animation instead of full-screen overlay
+   * while AI question/evaluation requests are in flight.
    * @private
    */
   async _runWithLoading(task) {
-    this.queueLoadingWork();
+    this._startAiLoadingToast();
     try {
       return await task();
     } finally {
-      this.finishLoadingWork();
+      this._stopAiLoadingToast();
     }
+  }
+
+  _startAiLoadingToast() {
+    this._aiLoadingPending += 1;
+    if (this._aiLoadingToastTimer) {
+      return;
+    }
+
+    const frames = ['◴', '◷', '◶', '◵'];
+    const renderFrame = () => {
+      const glyph = frames[this._aiLoadingFrame % frames.length];
+      this.showToast?.(`${glyph} Desk AI is thinking...`);
+      this._aiLoadingFrame += 1;
+    };
+
+    renderFrame();
+    this._aiLoadingToastTimer = setInterval(renderFrame, 420);
+  }
+
+  _stopAiLoadingToast() {
+    this._aiLoadingPending = Math.max(0, this._aiLoadingPending - 1);
+    if (this._aiLoadingPending > 0) {
+      return;
+    }
+
+    if (this._aiLoadingToastTimer) {
+      clearInterval(this._aiLoadingToastTimer);
+      this._aiLoadingToastTimer = null;
+    }
+
+    this._aiLoadingFrame = 0;
+    this.present?.clearToast?.();
   }
 
   /**
@@ -847,6 +883,10 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
    */
   destroy() {
     document.removeEventListener('keydown', this._handleMissionDeskKeyDownBound);
+    if (this._aiLoadingToastTimer) {
+      clearInterval(this._aiLoadingToastTimer);
+      this._aiLoadingToastTimer = null;
+    }
     super.destroy();
   }
 

--- a/_projects/cs-pathway-game/levels/Present.js
+++ b/_projects/cs-pathway-game/levels/Present.js
@@ -75,6 +75,10 @@ class Present {
     this._removeNode('panel');
   }
 
+  clearToast() {
+    this._removeNode('toast');
+  }
+
   clearAlerts() {
     this._removeNode('alerts');
   }


### PR DESCRIPTION
Originally the AI NPC was using the loading screen animation used for when the player switches from level to level. Now it uses a simple notification top-right to indicate that the AI is thinking, which is more appropriate at least than using the level loading screen.