### PR TITLE
Add Liquid Ruby4 patch and update Gemfile to support Ruby 4.0.0 and up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,17 @@
 source "https://rubygems.org"
 
-gem "github-pages", group: :jekyll_plugins
+gem "csv"
+gem "bigdecimal"
+gem "base64"
+
+gem "jekyll", "~> 3.9.0"
+gem "jekyll-theme-minima"
+gem "jekyll-remote-theme"
+gem "jekyll-include-cache"
+gem "kramdown-parser-gfm"
 
 gem "webrick", "~> 1.7"
-
 gem "execjs", "~> 2.8"
-gem "faraday-retry", "~> 2.3"
 
+# Require patch for Liquid 4.0.3 + Ruby 4.0 compatibility
+require_relative "liquid_ruby4_patch"

--- a/liquid_ruby4_patch.rb
+++ b/liquid_ruby4_patch.rb
@@ -1,0 +1,19 @@
+# Patch for Liquid 4.0.3 to support Ruby 4.0+
+# The taint-tracking security model was removed in Ruby 3.2, we add it back here to prevent errors in Liquid 4.0.3 which still uses it
+
+
+if RUBY_VERSION >= "3.2"
+  class Object
+    def tainted?
+      false
+    end
+
+    def taint
+      self
+    end
+
+    def untaint
+      self
+    end
+  end
+end


### PR DESCRIPTION
Replace github-pages with explicit Jekyll/runtime gems and plugins (jekyll 3.9, minima theme, remote-theme, include-cache, kramdown-parser-gfm) and add stdlib gems (csv, bigdecimal, base64). Keep webrick and execjs, remove faraday-retry. Add require_relative to load a new liquid_ruby4_patch.rb which reintroduces taint/tainted?/untaint no-ops for Ruby >= 3.2 to maintain compatibility with Liquid 4.0.3.

Test Repo: https://github.com/TDWolff-Developer-Org/pages/tree/main