### PR TITLE
Make AI chat sessions abort when closed

### DIFF
--- a/_projects/cs-pathway-game/levels/GameLevelCsPath2Mission.js
+++ b/_projects/cs-pathway-game/levels/GameLevelCsPath2Mission.js
@@ -336,7 +336,7 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
         try {
           this.showToast?.(`${deskId}: challenge channel opened.`);
           AiChallengeNpc.showInteraction(npc);
-          const challengeQuestion = await this._runWithLoading(() => this._loadDeskChallengeQuestion(npc.spriteData));
+          const challengeQuestion = await this._runWithLoading(() => this._loadDeskChallengeQuestion(npc.spriteData, npc?.aiSession || null));
           this._appendDeskChatMessage(npc, 'ai', `Challenge Question: ${challengeQuestion}`);
           AiChallengeNpc.deliverQuestion(npc, challengeQuestion);
           AiChallengeNpc.armSubmission(
@@ -421,12 +421,12 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
    * to avoid repeating a question already seen this session.
    * @private
    */
-  async _loadDeskChallengeQuestion(spriteData) {
+  async _loadDeskChallengeQuestion(spriteData, session = null) {
     let lastQuestion = '';
 
     for (let attempt = 0; attempt < 3; attempt += 1) {
       const prompt = this._buildChallengePrompt(spriteData);
-      const raw = await this._requestChallengeAiText(spriteData, prompt);
+      const raw = await this._requestChallengeAiText(spriteData, prompt, session);
       const question = AiChallengeNpc.extractFirstLine(raw);
       lastQuestion = question;
 
@@ -445,9 +445,9 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
    * then parses the graded verdict and feedback.
    * @private
    */
-  async _loadChallengeEvaluation(spriteData, question, answer) {
+  async _loadChallengeEvaluation(spriteData, question, answer, session = null) {
     const prompt = this._buildChallengeEvaluationPrompt(spriteData, question, answer);
-    const raw = await this._requestChallengeAiText(spriteData, prompt);
+    const raw = await this._requestChallengeAiText(spriteData, prompt, session);
     return this._parseChallengeEvaluation(raw);
   }
 
@@ -455,8 +455,8 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
    * Request AI text. Routes the prompt through AiChallengeNpc.
    * @private
    */
-  async _requestChallengeAiText(spriteData, prompt) {
-    return AiChallengeNpc.requestAiText(spriteData, prompt, 'mission-challenge', 'Mission Tools challenge generation');
+  async _requestChallengeAiText(spriteData, prompt, session = null) {
+    return AiChallengeNpc.requestAiText(spriteData, prompt, 'mission-challenge', 'Mission Tools challenge generation', session);
   }
 
   /**
@@ -623,7 +623,7 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
         try {
           ui.input.value = '';
           const evaluation = await this._runWithLoading(() =>
-            this._loadChallengeEvaluation(npc?.spriteData, active.question, answer)
+            this._loadChallengeEvaluation(npc?.spriteData, active.question, answer, npc?.aiSession || null)
           );
           AiChallengeNpc.renderEvaluation(ui.responseArea, active.question, answer, evaluation);
           AiChallengeNpc.speakEvaluation(npc, evaluation);

--- a/assets/js/GameEnginev1.1/essentials/AiChallengeNpc.js
+++ b/assets/js/GameEnginev1.1/essentials/AiChallengeNpc.js
@@ -76,9 +76,9 @@ class AiChallengeNpc extends AiNpc {
    * @param {string} [knowledgeContext='']       - Optional context hint for backend.
    * @returns {Promise<string>} Raw AI response text.
    */
-  static async requestAiText(spriteData, prompt, sessionPrefix = 'challenge', knowledgeContext = '') {
+  static async requestAiText(spriteData, prompt, sessionPrefix = 'challenge', knowledgeContext = '', session = null) {
     const payload = AiChallengeNpc.buildPayload(spriteData, prompt, sessionPrefix, knowledgeContext);
-    const response = await AiChallengeNpc.postRequest(payload);
+    const response = await AiChallengeNpc.postRequest(payload, session);
     const data = await AiChallengeNpc.parseResponseData(response);
     return AiChallengeNpc.extractAiResponseText(data);
   }
@@ -99,11 +99,12 @@ class AiChallengeNpc extends AiNpc {
   /**
    * POST to the AI backend; throws a typed error on non-2xx responses.
    */
-  static async postRequest(payload) {
+  static async postRequest(payload, session = null) {
     const pythonURL = `${pythonURI}/api/ainpc/prompt`;
     const response = await fetch(pythonURL, {
       ...fetchOptions,
       method: 'POST',
+      signal: session?.signal,
       body: JSON.stringify(payload),
     });
 
@@ -213,6 +214,11 @@ class AiChallengeNpc extends AiNpc {
       });
     }
 
+    const session = AiNpc.beginSession(npc);
+    if (npc.dialogueSystem?.setLifecycleSession) {
+      npc.dialogueSystem.setLifecycleSession(session);
+    }
+
     // Show the dialogue box using the NPC name / avatar but with a fixed
     // challenge-mode title rather than cycling through the dialogues array.
     npc.dialogueSystem?.showRandomDialogue(data.id, data.src, data);
@@ -248,7 +254,13 @@ class AiChallengeNpc extends AiNpc {
     AiNpc.attachToDialogue(npc.dialogueSystem, ui.container);
 
     // Auto-focus once the DOM has settled.
-    setTimeout(() => ui.inputField?.focus(), 100);
+    if (session) {
+      session.setTimeout(() => {
+        if (AiNpc.canUseElement(ui.inputField, session)) ui.inputField.focus();
+      }, 100);
+    } else {
+      setTimeout(() => ui.inputField?.focus(), 100);
+    }
   }
 
   /**
@@ -278,6 +290,8 @@ class AiChallengeNpc extends AiNpc {
    * @param {string} questionText  - Generated question string.
    */
   static deliverQuestion(npc, questionText) {
+    if (!AiNpc.isSessionActive(npc?.aiSession)) return;
+
     // Re-enable input now that the question is ready.
     const ui = AiChallengeNpc.getUiElements(npc);
     if (ui?.input) ui.input.disabled = false;
@@ -292,6 +306,8 @@ class AiChallengeNpc extends AiNpc {
    * Inject a question string into the response area and update the input placeholder.
    */
   static renderQuestion(npc, questionText) {
+    if (!AiNpc.isSessionActive(npc?.aiSession)) return;
+
     const ui = AiChallengeNpc.getUiElements(npc);
     if (!ui) return;
 
@@ -373,7 +389,8 @@ class AiChallengeNpc extends AiNpc {
    * The active challenge remains open and the follow-up is not scored.
    */
   static async handleChallengeFollowUpQuestion(npc, deskId, challengeQuestion, followUpQuestion, ui, activeChallenges = null, npcId = '') {
-    if (!npc?.spriteData || !ui?.responseArea) return;
+    const session = npc?.aiSession || null;
+    if (!npc?.spriteData || !ui?.responseArea || !AiNpc.canUseElement(ui.responseArea, session)) return;
 
     AiChallengeNpc.appendChatMessage(ui.responseArea, 'user', followUpQuestion);
     AiChallengeNpc.appendChatMessage(ui.responseArea, 'ai', 'Thinking about a safe hint...');
@@ -392,7 +409,10 @@ class AiChallengeNpc extends AiNpc {
         prompt,
         'mission-challenge-followup',
         'Mission Tools challenge follow-up assistance',
+        session,
       );
+
+      if (!AiNpc.canUseElement(ui.responseArea, session)) return;
 
       const safeReply = AiChallengeNpc.sanitizeFollowUpReply(raw);
       AiChallengeNpc.appendChatMessage(ui.responseArea, 'ai', safeReply);
@@ -407,6 +427,9 @@ class AiChallengeNpc extends AiNpc {
 
       AiChallengeNpc.updateJumpToLatestVisibility(ui.responseArea);
     } catch (error) {
+      if (error?.name === 'AbortError' || session?.signal?.aborted) {
+        return;
+      }
       console.warn(`[AiChallengeNpc] follow-up hint failed for ${deskId}:`, error);
       const fallbackReply = 'I can give a hint, but I cannot reveal the full answer. Try focusing on the next step or the key concept the question is testing.';
       AiChallengeNpc.appendChatMessage(ui.responseArea, 'ai', fallbackReply);

--- a/assets/js/GameEnginev1.1/essentials/AiNpc.js
+++ b/assets/js/GameEnginev1.1/essentials/AiNpc.js
@@ -17,9 +17,36 @@
  */
 
 import DialogueSystem from './DialogueSystem.js';
+import AiNpcSession from './AiNpcSession.js';
 import { pythonURI, fetchOptions } from '../../api/config.js';
 
 class AiNpc {
+    static beginSession(npcInstance) {
+        if (!npcInstance) return null;
+
+        if (npcInstance.aiSession) {
+            npcInstance.aiSession.cancel();
+        }
+
+        npcInstance.aiSession = new AiNpcSession(npcInstance?.spriteData?.id || 'npc');
+
+        if (npcInstance.dialogueSystem?.setLifecycleSession) {
+            npcInstance.dialogueSystem.setLifecycleSession(npcInstance.aiSession);
+        }
+
+        return npcInstance.aiSession;
+    }
+
+    static isSessionActive(session) {
+        return !!session && typeof session.isActive === 'function' && session.isActive();
+    }
+
+    static canUseElement(element, session) {
+        if (!element || !element.isConnected) return false;
+        if (!session) return true;
+        return AiNpc.isSessionActive(session);
+    }
+
     /**
      * Main entry point - Shows full AI interaction dialog for an NPC
      * Creates DialogueSystem with NPC's dialogues and uses cycling behavior
@@ -40,6 +67,11 @@ class AiNpc {
                 dialogues: data.dialogues || [data.greeting || "Hello!"],
                 gameControl: npc.gameControl
             });
+        }
+
+        const session = AiNpc.beginSession(npc);
+        if (npc.dialogueSystem?.setLifecycleSession) {
+            npc.dialogueSystem.setLifecycleSession(session);
         }
 
         // Use DialogueSystem's cycling showRandomDialogue method
@@ -111,6 +143,7 @@ class AiNpc {
      */
     static attachEventHandlers(npcInstance, spriteData, ui) {
         const { inputField, historyBtn, responseArea } = ui;
+        const session = npcInstance?.aiSession || null;
 
         // History button
         historyBtn.onclick = () => AiNpc.showChatHistory(spriteData);
@@ -120,11 +153,11 @@ class AiNpc {
             const userMessage = inputField.value.trim();
             if (!userMessage) return;
             inputField.value = '';
-            await AiNpc.sendPromptToBackend(spriteData, userMessage, responseArea);
+            await AiNpc.sendPromptToBackend(npcInstance, userMessage, responseArea);
         };
 
         // Prevent game input while typing
-        AiNpc.preventGameInput(inputField);
+        AiNpc.preventGameInput(inputField, session);
 
         // Handle Enter key (Shift+Enter for new line, Enter to send)
         inputField.onkeypress = e => {
@@ -136,7 +169,13 @@ class AiNpc {
         };
 
         // Auto-focus input field
-        setTimeout(() => inputField.focus(), 100);
+        if (session) {
+            session.setTimeout(() => {
+                if (AiNpc.canUseElement(inputField, session)) inputField.focus();
+            }, 100);
+        } else {
+            setTimeout(() => inputField.focus(), 100);
+        }
     }
 
     /**
@@ -167,11 +206,20 @@ class AiNpc {
      * @param {string} userMessage - User's message
      * @param {HTMLElement} responseArea - Response display element
      */
-    static async sendPromptToBackend(spriteData, userMessage, responseArea) {
+    static async sendPromptToBackend(npcInstance, userMessage, responseArea) {
+        const spriteData = npcInstance?.spriteData || npcInstance;
+        const session = npcInstance?.aiSession || null;
+
+        if (!spriteData || !Array.isArray(spriteData.chatHistory)) {
+            return;
+        }
+
         spriteData.chatHistory.push({ role: 'user', message: userMessage });
 
-        responseArea.textContent = 'Thinking...';
-        responseArea.style.display = 'block';
+        if (AiNpc.canUseElement(responseArea, session)) {
+            responseArea.textContent = 'Thinking...';
+            responseArea.style.display = 'block';
+        }
 
         try {
             // Build knowledge context
@@ -191,6 +239,7 @@ class AiNpc {
             const response = await fetch(pythonURL, {
                 ...fetchOptions,
                 method: 'POST',
+                signal: session?.signal,
                 body: JSON.stringify({
                     prompt: userMessage,
                     session_id: sessionId,
@@ -202,24 +251,37 @@ class AiNpc {
 
             const data = await response.json();
 
+            if (!AiNpc.canUseElement(responseArea, session)) {
+                return;
+            }
+
             if (data.status === 'error') {
                 AiNpc.showResponse(
                     data.message || "I'm having trouble thinking right now.",
-                    responseArea
+                    responseArea,
+                    30,
+                    session,
                 );
                 return;
             }
 
             const aiResponse = data?.response || "I'm not sure how to answer that yet.";
             spriteData.chatHistory.push({ role: 'ai', message: aiResponse });
-            AiNpc.showResponse(aiResponse, responseArea);
+            AiNpc.showResponse(aiResponse, responseArea, 30, session);
 
         } catch (err) {
+            if (err?.name === 'AbortError' || session?.signal?.aborted) {
+                return;
+            }
             console.error('Frontend error:', err);
-            AiNpc.showResponse(
-                "I'm having trouble reaching my brain right now.",
-                responseArea
-            );
+            if (AiNpc.canUseElement(responseArea, session)) {
+                AiNpc.showResponse(
+                    "I'm having trouble reaching my brain right now.",
+                    responseArea,
+                    30,
+                    session,
+                );
+            }
         }
     }
 
@@ -229,14 +291,26 @@ class AiNpc {
      * @param {HTMLElement} element - Element to display in
      * @param {number} speed - Typing speed in ms
      */
-    static showResponse(text, element, speed = 30) {
+    static showResponse(text, element, speed = 30, session = null) {
+        if (!AiNpc.canUseElement(element, session)) return;
+
         element.textContent = '';
         element.style.display = 'block';
         let index = 0;
+
+        const scheduleNext = (fn) => {
+            if (session) {
+                session.setTimeout(fn, speed);
+                return;
+            }
+            setTimeout(fn, speed);
+        };
+
         const type = () => {
+            if (!AiNpc.canUseElement(element, session)) return;
             if (index < text.length) {
                 element.textContent += text.charAt(index++);
-                setTimeout(type, speed);
+                scheduleNext(type);
             }
         };
         type();
@@ -246,9 +320,14 @@ class AiNpc {
      * Prevent keyboard events from propagating to game
      * @param {HTMLElement} element - Input element to protect
      */
-    static preventGameInput(element) {
+    static preventGameInput(element, session = null) {
         ['keydown', 'keyup', 'keypress'].forEach(eventType => {
-            element.addEventListener(eventType, e => e.stopPropagation());
+            const handler = (e) => e.stopPropagation();
+            if (session) {
+                session.addListener(element, eventType, handler);
+            } else {
+                element.addEventListener(eventType, handler);
+            }
         });
     }
 

--- a/assets/js/GameEnginev1.1/essentials/AiNpcSession.js
+++ b/assets/js/GameEnginev1.1/essentials/AiNpcSession.js
@@ -1,0 +1,60 @@
+class AiNpcSession {
+  constructor(npcId = 'npc') {
+    this.npcId = npcId;
+    this._abortController = new AbortController();
+    this._active = true;
+    this._timeouts = new Set();
+    this._listeners = [];
+  }
+
+  get signal() {
+    return this._abortController.signal;
+  }
+
+  isActive() {
+    return this._active && !this.signal.aborted;
+  }
+
+  setTimeout(callback, delay) {
+    const id = setTimeout(() => {
+      this._timeouts.delete(id);
+      if (!this.isActive()) return;
+      callback();
+    }, delay);
+
+    this._timeouts.add(id);
+    return id;
+  }
+
+  addListener(target, eventName, handler, options) {
+    if (!target || typeof target.addEventListener !== 'function') return;
+
+    target.addEventListener(eventName, handler, options);
+    this._listeners.push({ target, eventName, handler, options });
+  }
+
+  cancel() {
+    if (!this._active) return;
+    this._active = false;
+
+    try {
+      this._abortController.abort();
+    } catch (_error) {
+      // no-op
+    }
+
+    this._timeouts.forEach((id) => clearTimeout(id));
+    this._timeouts.clear();
+
+    this._listeners.forEach(({ target, eventName, handler, options }) => {
+      try {
+        target.removeEventListener(eventName, handler, options);
+      } catch (_error) {
+        // no-op
+      }
+    });
+    this._listeners = [];
+  }
+}
+
+export default AiNpcSession;

--- a/assets/js/GameEnginev1.1/essentials/DialogueSystem.js
+++ b/assets/js/GameEnginev1.1/essentials/DialogueSystem.js
@@ -36,6 +36,7 @@ constructor(options = {}) {
   this.voiceRate = options.voiceRate !== undefined ? options.voiceRate : 0.9;
   this.voicePitch = options.voicePitch !== undefined ? options.voicePitch : 1.0;
   this.voiceVolume = options.voiceVolume !== undefined ? options.voiceVolume : 1.0;
+  this.lifecycleSession = null;
    // Create the dialogue box
   this.createDialogueBox();
    // Keep track of whether the dialogue is currently open
@@ -298,6 +299,10 @@ createDialogueBox() {
   });
 }
 
+setLifecycleSession(session) {
+  this.lifecycleSession = session || null;
+}
+
 
 
 
@@ -445,11 +450,20 @@ showRandomDialogue(speaker = "", avatarSrc = null, spriteData = null) {
 // Close the dialogue box
 closeDialogue() {
   if (!this.isOpen) return;
+
+  if (this.lifecycleSession) {
+    this.lifecycleSession.cancel();
+    this.lifecycleSession = null;
+  }
+
    // Clear typewriter timeout
   if (this.typewriterTimeoutId) {
     clearTimeout(this.typewriterTimeoutId);
+    this.typewriterTimeoutId = null;
   }
-   // Leave speech running so queued lines can finish naturally.
+
+  DialogueSystem.flushSpeechQueue();
+
    // Hide the dialogue box
   this.dialogueBox.style.display = "none";
   this.isOpen = false;


### PR DESCRIPTION
Sessions for AI NPCs are now structured in a manner that once you leave a chat session, everything involving that session will abort and end, which makes for a much cleaner and effective design for the sessions.