### PR TITLE
Wait for player to answer question before asking another

### DIFF
--- a/_projects/cs-pathway-game/levels/GameLevelCsPath2Mission.js
+++ b/_projects/cs-pathway-game/levels/GameLevelCsPath2Mission.js
@@ -327,6 +327,15 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
     if (!npc?.spriteData?.id) return;
 
     const npcId = npc.spriteData.id;
+    const historyPendingQuestion = this._getPendingQuestionFromChatHistory(npc);
+    const activeChallenge = this._activeDeskChallenges.get(npcId) || null;
+    const lockedQuestion = AiChallengeNpc.getPendingChallengeQuestion(deskId);
+    const stateQuestion = (AiChallengeNpc.getChallengeState(npc)?.question || '').toString().trim();
+    const hasPendingChallenge = Boolean(historyPendingQuestion || lockedQuestion) || AiChallengeNpc.hasPendingChallenge(npc, deskId) || (
+      Boolean(activeChallenge?.question) &&
+      !activeChallenge?.completedAt &&
+      activeChallenge?.lastEvaluation?.verdict !== CHALLENGE_VERDICTS.RIGHT
+    );
     // Orchestrator: open UI, generate one question, then arm answer submission.
     await this._runBusyTask({
       busySet: this._deskChallengeBusy,
@@ -334,11 +343,23 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
       busyMessage: `${deskId}: challenge is already loading.`,
       task: async () => {
         try {
-          this.showToast?.(`${deskId}: challenge channel opened.`);
-          AiChallengeNpc.showInteraction(npc);
-          const challengeQuestion = await this._runWithLoading(() => this._loadDeskChallengeQuestion(npc.spriteData, npc?.aiSession || null));
-          this._appendDeskChatMessage(npc, 'ai', `Challenge Question: ${challengeQuestion}`);
-          AiChallengeNpc.deliverQuestion(npc, challengeQuestion);
+          this.showToast?.(hasPendingChallenge ? `${deskId}: resuming your current challenge.` : `${deskId}: challenge channel opened.`);
+          AiChallengeNpc.showInteraction(npc, {
+            statusMessage: hasPendingChallenge ? null : 'Generating challenge question…',
+          });
+
+          const challengeQuestion = hasPendingChallenge
+            ? (historyPendingQuestion || lockedQuestion || stateQuestion || activeChallenge?.question)
+            : await this._runWithLoading(() => this._loadDeskChallengeQuestion(npc.spriteData, npc?.aiSession || null));
+
+          if (hasPendingChallenge) {
+            AiChallengeNpc.restoreQuestion(npc, challengeQuestion);
+          } else {
+            AiChallengeNpc.setPendingChallenge(npc, deskId, challengeQuestion);
+            this._appendDeskChatMessage(npc, 'ai', `Challenge Question: ${challengeQuestion}`);
+            AiChallengeNpc.deliverQuestion(npc, challengeQuestion);
+          }
+
           AiChallengeNpc.armSubmission(
             npc, deskId, challengeQuestion, this._activeDeskChallenges,
             (answer, active, ui) => this._submitChallengeAnswer(npc, npcId, answer, active, ui),
@@ -607,12 +628,41 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
   }
 
   /**
+   * Return the most recent unresolved challenge question from transcript history.
+   * A question is unresolved when no Result line appears after it.
+   * @private
+   */
+  _getPendingQuestionFromChatHistory(npc) {
+    const history = npc?.spriteData?.chatHistory;
+    if (!Array.isArray(history) || history.length === 0) return '';
+
+    let pending = '';
+    for (let i = history.length - 1; i >= 0; i -= 1) {
+      const entry = history[i];
+      const message = (entry?.message || '').toString().trim();
+      if (!message) continue;
+
+      if (/^Result\s*:/i.test(message)) {
+        return '';
+      }
+
+      if (/^Challenge Question\s*:/i.test(message)) {
+        pending = message.replace(/^Challenge Question\s*:\s*/i, '').trim();
+        break;
+      }
+    }
+
+    return pending;
+  }
+
+  /**
    * Submit answer. Evaluates the student answer, renders feedback, speaks
    * the result, and awards progress if correct. Called via onSubmit callback.
    * @private
    */
   async _submitChallengeAnswer(npc, npcId, answer, active, ui) {
     if (!active?.question) return;
+    AiChallengeNpc.markChallengeAnswered(npc, answer);
     this._appendDeskChatMessage(npc, 'user', answer);
 
     await this._runBusyTask({
@@ -638,6 +688,8 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
             `Result: ${evaluation?.verdict || CHALLENGE_VERDICTS.WRONG}. ${evaluation?.feedback || 'No feedback provided.'}`
           );
           if (evaluation?.verdict === CHALLENGE_VERDICTS.RIGHT) {
+            active.status = 'completed';
+            active.completedAt = Date.now();
             this._awardMissionProgress(active?.deskId || '');
           }
           this._logChallengeEvent({

--- a/assets/js/GameEnginev1.1/essentials/AiChallengeNpc.js
+++ b/assets/js/GameEnginev1.1/essentials/AiChallengeNpc.js
@@ -197,9 +197,12 @@ class AiChallengeNpc extends AiNpc {
    *
    * @param {Object} npc - Live NPC game object.
    */
-  static showInteraction(npc) {
+  static showInteraction(npc, options = {}) {
     const data = npc?.spriteData;
     if (!data) return;
+    const statusMessage = options?.statusMessage !== undefined
+      ? options.statusMessage
+      : 'Generating challenge question…';
 
     // Close any already-open dialogue for this NPC.
     if (npc.dialogueSystem?.isDialogueOpen()) {
@@ -248,7 +251,9 @@ class AiChallengeNpc extends AiNpc {
       AiChallengeNpc.ensureModeLabel(ui.container, 'Challenge Question');
       AiChallengeNpc.ensureJumpToLatestButton(ui.responseArea);
       AiChallengeNpc.renderChatHistory(ui.responseArea, data?.chatHistory || []);
-      AiChallengeNpc.appendChatMessage(ui.responseArea, 'ai', 'Generating challenge question…');
+      if (statusMessage) {
+        AiChallengeNpc.appendChatMessage(ui.responseArea, 'ai', statusMessage);
+      }
     }
 
     AiNpc.attachToDialogue(npc.dialogueSystem, ui.container);
@@ -321,6 +326,116 @@ class AiChallengeNpc extends AiNpc {
     }
   }
 
+  /**
+   * Restore an already-issued challenge question after the dialogue is reopened.
+   * This keeps the existing question on screen without generating a new one.
+   */
+  static restoreQuestion(npc, questionText) {
+    if (!AiNpc.isSessionActive(npc?.aiSession)) return;
+
+    const ui = AiChallengeNpc.getUiElements(npc);
+    if (!ui) return;
+
+    if (ui.input) {
+      ui.input.disabled = false;
+      ui.input.placeholder = 'Type your answer to the challenge question...';
+    }
+
+    if (ui.responseArea) {
+      ui.responseArea.style.display = 'block';
+      ui.responseArea.scrollTop = ui.responseArea.scrollHeight;
+      AiChallengeNpc.updateJumpToLatestVisibility(ui.responseArea);
+    }
+  }
+
+  /**
+   * Return the current challenge lock state stored on the live NPC object.
+   */
+  static getChallengeState(npc) {
+    return npc?._aiChallengeState || null;
+  }
+
+  /**
+   * Shared lock registry so pending questions survive object churn.
+   */
+  static getChallengeLocks() {
+    if (!AiChallengeNpc._challengeLocks) {
+      AiChallengeNpc._challengeLocks = new Map();
+    }
+    return AiChallengeNpc._challengeLocks;
+  }
+
+  /**
+   * Read the current pending challenge question for a desk, if any.
+   */
+  static getPendingChallengeQuestion(deskId = '') {
+    const key = (deskId || '').toString().trim();
+    if (!key) return '';
+    return (AiChallengeNpc.getChallengeLocks().get(key) || '').toString().trim();
+  }
+
+  /**
+   * Set or clear the pending challenge question lock for a desk.
+   */
+  static setPendingChallengeQuestion(deskId = '', questionText = '') {
+    const key = (deskId || '').toString().trim();
+    if (!key) return;
+
+    const value = (questionText || '').toString().trim();
+    const locks = AiChallengeNpc.getChallengeLocks();
+    if (!value) {
+      locks.delete(key);
+      return;
+    }
+    locks.set(key, value);
+  }
+
+  /**
+   * True when the NPC has an issued challenge question that has not been answered yet.
+   */
+  static hasPendingChallenge(npc, deskId = '') {
+    const lockedQuestion = AiChallengeNpc.getPendingChallengeQuestion(deskId);
+    if (lockedQuestion) return true;
+
+    const state = AiChallengeNpc.getChallengeState(npc);
+    if (!state?.question || state?.answeredAt) return false;
+    if (!deskId) return true;
+    return state.deskId === deskId;
+  }
+
+  /**
+   * Lock a freshly-issued challenge question on the NPC until a player submits an answer.
+   */
+  static setPendingChallenge(npc, deskId, questionText) {
+    if (!npc || !questionText) return;
+
+    AiChallengeNpc.setPendingChallengeQuestion(deskId, questionText);
+
+    npc._aiChallengeState = {
+      deskId: deskId || npc?.spriteData?.id || 'desk',
+      question: String(questionText),
+      issuedAt: Date.now(),
+      answeredAt: null,
+      lastAnswer: '',
+    };
+  }
+
+  /**
+   * Mark the current locked challenge as answered so reopening can generate a new one.
+   */
+  static markChallengeAnswered(npc, answerText = '') {
+    const state = AiChallengeNpc.getChallengeState(npc);
+    if (!npc || !state?.question || state?.answeredAt) return;
+
+    AiChallengeNpc.setPendingChallengeQuestion(state.deskId, '');
+
+    npc._aiChallengeState = {
+      ...state,
+      answeredAt: Date.now(),
+      lastAnswer: (answerText || '').toString(),
+    };
+  }
+
   // ── Answer submission ───────────────────────────────────────────────────────
 
   /**
@@ -343,6 +458,7 @@ class AiChallengeNpc extends AiNpc {
       deskId,
       question: challengeQuestion,
       startedAt: Date.now(),
+      status: 'pending',
     });
 
     ui.input.value = '';


### PR DESCRIPTION
Currently, if I go to one of the AI NPCs, get a question from the NPC, and leave and reopen the dialogue, a new challenge question will appear even if I never answer the initial question.

Below is an example of this occurring:
<img width="799" height="633" alt="image" src="https://github.com/user-attachments/assets/72889d9a-fead-403a-af6e-e3b1f7902fde" />

The changes in this pull request inhibit the ability of the AI NPC to ask new questions if the player doesn't answer the question or gets the question wrong, even if the player reopens the dialogue.