### PR TITLE
Increase difficulty of questions once score is 4/4

### DIFF
--- a/_projects/cs-pathway-game/levels/GameLevelCsPath2Mission.js
+++ b/_projects/cs-pathway-game/levels/GameLevelCsPath2Mission.js
@@ -21,6 +21,10 @@ const CHALLENGE_PROMPT_TEXT = {
   QUESTION_RECENT_HEADER: 'Recently used questions to avoid repeating:\n{{recentQuestions}}',
   QUESTION_ANTI_REPEAT: 'Do not repeat or closely paraphrase any recent question. Prefer a fresh angle each time.',
   QUESTION_UNIQUE_STYLE: 'Choose a different question style than the recent examples when possible.',
+  QUESTION_ADVANCED_MODE: 'Mission scoreboard is 4/4. Switch to advanced mode and make the question noticeably harder.',
+  QUESTION_ADVANCED_FOCUS: 'Ask for deeper understanding, not just a memorized fact.',
+  QUESTION_ADVANCED_RULES: 'Use a question that may combine two related ideas, require a comparison, or ask for a troubleshooting choice.',
+  QUESTION_ADVANCED_KEEP_SHORT: 'Keep the question concise, but more challenging than the earlier desk questions.',
 
   EVAL_ROLE: 'You are grading a student answer for {{deskName}}.',
   EVAL_EXPERTISE: 'Desk expertise: {{expertise}}.',
@@ -43,6 +47,17 @@ const CHALLENGE_QUESTION_STYLES = [
   'Ask for one small action before running code.',
   'Ask for one clear yes/no understanding check with a short explanation.',
   'Ask for one beginner-friendly definition using simple words.',
+];
+
+const CHALLENGE_ADVANCED_QUESTION_STYLES = [
+  'Ask for a two-step explanation that connects a command or concept to a result.',
+  'Ask which option is better and why, using one concrete reason.',
+  'Ask for a small troubleshooting decision with a likely fix.',
+  'Ask for a more specific command, file, or setting and what it changes.',
+  'Ask for a brief compare-and-contrast between two related terms.',
+  'Ask for one practical workflow step plus a short reason it matters.',
+  'Ask a scenario question that needs the student to choose the correct action.',
+  'Ask for a short explanation that uses at least two key terms correctly.',
 ];
 
 const CHALLENGE_RECENT_HISTORY_LIMIT = 12;
@@ -621,6 +636,7 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
   _buildChallengePrompt(spriteData) {
     const expertise = spriteData?.expertise || 'general problem solving';
     const deskName = spriteData?.id || 'Desk Guide';
+    const advancedMode = (this._missionProgressCount || 0) >= 4;
     const sampleTopics = (spriteData?.knowledgeBase?.[deskName]?.questions || [])
       .slice(0, 8)
       .map((topic) => `- ${topic.question}`)
@@ -629,22 +645,23 @@ class GameLevelCsPath2Mission extends GameLevelCsPathIdentity {
       .slice(-CHALLENGE_RECENT_HISTORY_LIMIT)
       .map((question) => `- ${question}`)
       .join('\n');
-    const questionStyles = CHALLENGE_QUESTION_STYLES
+    const questionStyles = (advancedMode ? CHALLENGE_ADVANCED_QUESTION_STYLES : CHALLENGE_QUESTION_STYLES)
       .map((style, index) => `${index + 1}. ${style}`)
       .join('\n');
 
     return [
       CHALLENGE_PROMPT_TEXT.QUESTION_ROLE.replace('{{deskName}}', deskName),
       CHALLENGE_PROMPT_TEXT.QUESTION_FOCUS.replace('{{expertise}}', expertise),
+      advancedMode ? CHALLENGE_PROMPT_TEXT.QUESTION_ADVANCED_MODE : CHALLENGE_PROMPT_TEXT.QUESTION_BEGINNER_LEVEL,
       CHALLENGE_PROMPT_TEXT.QUESTION_CONCISE,
       CHALLENGE_PROMPT_TEXT.QUESTION_SHORT_ANSWER,
-      CHALLENGE_PROMPT_TEXT.QUESTION_BEGINNER_LEVEL,
-      CHALLENGE_PROMPT_TEXT.QUESTION_PLAIN_WORDS,
-      CHALLENGE_PROMPT_TEXT.QUESTION_NO_TRICKS,
+      advancedMode ? CHALLENGE_PROMPT_TEXT.QUESTION_ADVANCED_FOCUS : CHALLENGE_PROMPT_TEXT.QUESTION_PLAIN_WORDS,
+      advancedMode ? CHALLENGE_PROMPT_TEXT.QUESTION_ADVANCED_RULES : CHALLENGE_PROMPT_TEXT.QUESTION_NO_TRICKS,
       CHALLENGE_PROMPT_TEXT.QUESTION_ALLOWED_SHAPES,
       CHALLENGE_PROMPT_TEXT.QUESTION_FORMAT,
       CHALLENGE_PROMPT_TEXT.QUESTION_ANTI_REPEAT,
       CHALLENGE_PROMPT_TEXT.QUESTION_UNIQUE_STYLE,
+      advancedMode ? CHALLENGE_PROMPT_TEXT.QUESTION_ADVANCED_KEEP_SHORT : '',
       CHALLENGE_PROMPT_TEXT.QUESTION_VARIETY_HEADER.replace('{{questionStyles}}', questionStyles),
       recentQuestions ? CHALLENGE_PROMPT_TEXT.QUESTION_RECENT_HEADER.replace('{{recentQuestions}}', recentQuestions) : '',
       sampleTopics ? CHALLENGE_PROMPT_TEXT.QUESTION_TOPIC_HEADER.replace('{{sampleTopics}}', sampleTopics) : '',


### PR DESCRIPTION
I recently made a pull request that considerably lowered the difficulty of the questions asked, but once the player gets a 4/4 on the scoreboard, the difficulty should accordingly be raised once again.