### PR TITLE
Keep avatar forge open once sprite is selected

### DIFF
--- a/_projects/cs-pathway-game/levels/GameLevelCsPath0Forge.js
+++ b/_projects/cs-pathway-game/levels/GameLevelCsPath0Forge.js
@@ -99,6 +99,20 @@ class GameLevelCsPath0Forge {
         if (restored.identityState) {
           Object.assign(identityState, restored.identityState);
         }
+
+        identityState.identityUnlocked = Boolean(identityState.identityUnlocked);
+        identityState.worldThemeDone = Boolean(
+          identityState.worldThemeDone ||
+          identityState.worldThemeSelected ||
+          this.profileData?.themeMeta ||
+          this.profileData?.theme
+        );
+        identityState.avatarForgeDone = Boolean(
+          identityState.avatarForgeDone ||
+          identityState.avatarSelected ||
+          this.profileData?.spriteMeta ||
+          this.profileData?.sprite
+        );
         
         console.log('GameLevel: profile restored', {
           name: this.profileData?.name,
@@ -417,7 +431,14 @@ await this.profileManager.saveIdentity(profile);
       identityState.avatarFlowActive = true;
 
       try {
-        if (!identityState.worldThemeDone) {
+        const hasSavedAvatar = Boolean(
+          identityState.avatarForgeDone ||
+          identityState.avatarSelected ||
+          this.profileData?.spriteMeta ||
+          this.profileData?.sprite
+        );
+
+        if (!identityState.worldThemeDone && !hasSavedAvatar) {
           await this.showDialogue('Avatar Forge Gatekeeper', [
             'The Avatar Forge is locked.',
             'Complete the World Theme Portal first.'

--- a/_projects/cs-pathway-game/model/ProfileManager.js
+++ b/_projects/cs-pathway-game/model/ProfileManager.js
@@ -144,8 +144,10 @@ class ProfileManager {
       identityState: {
         // Identity Forge (includes avatar)
         identityUnlocked: profile.identityUnlocked || false,
+        avatarForgeDone: profile.avatarSelected || Boolean(profile.spriteMeta || profile.sprite),
         avatarSelected: profile.avatarSelected || false,
         // Wayfinding World
+        worldThemeDone: profile.worldThemeSelected || Boolean(profile.themeMeta || profile.theme),
         worldThemeSelected: profile.worldThemeSelected || false,
         navigationComplete: profile.navigationComplete || false,
         // Mission Tooling


### PR DESCRIPTION
Currently, the avatar forge, once opened, only stays open till the game is restarted. However, the changes in this pull request keeps the avatar forge open based on whether the user has a sprite registered in their profile or not.