### PR TITLE
Make Debugger (In terminal on Vscode Workspace)

### DIFF
--- a/make-debug/README.md
+++ b/make-debug/README.md
@@ -1,10 +1,12 @@
 # Make Debug
 
-A lightweight helper to run `make`, read `/tmp/jekyll4500.log`, and send the log to OpenAI for a recommendation.
+A lightweight helper to run `make`, read `/tmp/jekyll4500.log`, and send the log to Gemini AI for analysis using Spring Boot backend.
 
 ## Setup
 
-Install dependencies in your active environment or local venv:
+1. **Spring Backend**: Ensure the Spring Boot application is running on port 8585 with Gemini API key configured in `.env`
+
+2. **Frontend Dependencies**: Install Python dependencies in your active environment or local venv:
 
 ```bash
 pip install -r make-debug/requirements.txt
@@ -19,7 +21,7 @@ python make-debug/run.py
 This will:
 - run `make`
 - wait for `/tmp/jekyll4500.log`
-- send the log to the AI analyzer
+- send the log to the Spring Boot Gemini AI analyzer
 - print a short recommendation to the terminal
 
 If you want to run a different command instead of `make`, use:
@@ -27,3 +29,25 @@ If you want to run a different command instead of `make`, use:
 ```bash
 python make-debug/run.py --cmd "make build"
 ```
+
+## Backend Configuration
+
+The Spring Boot backend (`PersonService.java`) handles the Gemini AI integration:
+
+- API Key: Configured in `spring/.env` as `GEMINI_API_KEY`
+- Endpoint: `POST /api/gemini/analyze-log`
+- Port: 8585 (configured in `application.properties`)
+
+## Architecture
+
+- **Frontend**: Python script that runs make commands and captures logs
+- **Backend**: Spring Boot REST API with Gemini AI integration
+- **AI Analysis**: Jekyll build log analysis with actionable recommendations
+
+
+## Log Pattern Checker (Fast Diagnostics)
+
+You can quickly check for common Jekyll/make errors without using AI:
+
+```bash
+python make-debug/log_checker.py

--- a/make-debug/analyzer.py
+++ b/make-debug/analyzer.py
@@ -1,8 +1,6 @@
 import requests
-from prompt import SYSTEM_PROMPT
 
-BACKEND_URL = "http://localhost:8587/api/gemini/analyze-log"
-
+BACKEND_URL = "http://localhost:8585/api/make/analyze"
 
 def analyze_log(log: str) -> str:
     log = log[-8000:]  # prevent huge inputs
@@ -10,14 +8,10 @@ def analyze_log(log: str) -> str:
     try:
         response = requests.post(
             BACKEND_URL,
-            json={"log": log},
-            headers={"Content-Type": "application/json"}
+            data=log,
+            headers={"Content-Type": "text/plain"}
         )
         response.raise_for_status()
-        data = response.json()
-        if data.get("success"):
-            return data["analysis"]
-        else:
-            return f"Analysis failed: {data.get('message', 'Unknown error')}"
+        return response.text
     except requests.RequestException as e:
         return f"Backend request failed: {str(e)}"

--- a/make-debug/log_checker.py
+++ b/make-debug/log_checker.py
@@ -1,0 +1,114 @@
+# make-debug/log_checker.py
+
+import re
+from pathlib import Path
+from collections import Counter
+
+LOG_PATH = "/tmp/jekyll4500.log"
+
+
+def read_log(path: str = LOG_PATH) -> str:
+    log_path = Path(path)
+    if not log_path.exists():
+        raise FileNotFoundError(f"{path} does not exist")
+    return log_path.read_text(errors="ignore")
+
+
+def detect_post_url_issues(log_text: str):
+    """
+    Detects Jekyll post_url deprecation mismatches and extracts broken references.
+    """
+    pattern = r"\{\%\s*post_url\s+([^\s\%]+)\s*\%\}"
+    matches = re.findall(pattern, log_text)
+
+    if not matches:
+        return None
+
+    counts = Counter(matches)
+
+    issues = []
+    for post, count in counts.items():
+        issues.append({
+            "post": post,
+            "count": count
+        })
+
+    return issues
+
+
+def detect_general_issues(log_text: str):
+    """
+    Detects other common issues.
+    """
+    issues = []
+
+    if re.search(r"Permission denied", log_text, re.IGNORECASE):
+        issues.append(("permission_denied", "Fix file permissions or use sudo"))
+
+    if re.search(r"Address already in use", log_text, re.IGNORECASE):
+        issues.append(("port_in_use", "Kill process or change port"))
+
+    if re.search(r"Could not find gem", log_text, re.IGNORECASE):
+        issues.append(("missing_gem", "Run: bundle install"))
+
+    return issues
+
+
+def clean_output(post_url_issues, general_issues):
+    output = []
+
+    if not post_url_issues and not general_issues:
+        return "✅ No major issues detected."
+
+    output.append("⚠️ Issues Detected:\n")
+
+    # --- POST_URL ISSUES ---
+    if post_url_issues:
+        output.append("🔗 Broken post_url references:\n")
+
+        for issue in post_url_issues:
+            output.append(
+                f"- `{issue['post']}` (appears {issue['count']} times)"
+            )
+
+        output.append("\n📌 EXACT FIX:\n")
+        output.append(
+            "Your `{% post_url %}` tags do NOT match actual post filenames.\n"
+        )
+
+        output.append("Do this:\n")
+        output.append("1. Go to your `_posts/` folder")
+        output.append("2. Find the exact filename (example):")
+        output.append("   2026-02-06-hawkhub.md")
+        output.append("3. Make sure your tag matches EXACTLY:\n")
+        output.append("   {% post_url 2026-02-06-hawkhub %}\n")
+        output.append(
+            "⚠️ If the filename is different (even slightly), Jekyll will fail."
+        )
+
+    # --- GENERAL ISSUES ---
+    if general_issues:
+        output.append("\n🛠 Other Issues:\n")
+        for name, fix in general_issues:
+            output.append(f"- {name}")
+            output.append(f"  → Fix: {fix}")
+
+    return "\n".join(output)
+
+
+def main():
+    try:
+        log = read_log()
+
+        post_url_issues = detect_post_url_issues(log)
+        general_issues = detect_general_issues(log)
+
+        report = clean_output(post_url_issues, general_issues)
+        print(report)
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/make-debug/pages-educators.code-workspace
+++ b/make-debug/pages-educators.code-workspace
@@ -1,0 +1,14 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		},
+		{
+			"path": "../../flask-educators"
+		},
+		{
+			"path": "../../spring"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
## Summary

Refactors the Jekyll build debugger to route AI analysis through a Spring Boot backend, and adds a fast local log checker for common errors.

---

## Changes

### Architecture: Python → Spring Boot → Gemini

Direct OpenAI calls from Python have been replaced with a Spring Boot backend that handles authentication, API key management, and Gemini API communication. The Python script now sends raw log text to the backend and prints the plain-text response.

**Endpoint:** `POST :8585/api/make/analyze`  
**Request:** `Content-Type: text/plain` (raw log contents)  
**Response:** Plain text AI analysis

This decouples the AI provider from the frontend — swapping Gemini for another model only requires a backend change.

---

### New: `log_checker.py` — Local, Regex-Based Debugger

Adds a fast, offline log scanner that detects common Jekyll build failures without making any API calls:

- Broken `{% post_url %}` references
- Permission errors
- Port conflicts
- Missing gems

Run this first. It's instant and costs nothing. Fall back to AI analysis for issues it doesn't catch.

---

### `pages-educators.code-workspace`

Workspace file linking the main repo, Flask project, and Spring backend for easier multi-service development.

---

## How to Use

**1. Start the Spring Boot backend** (port `8585`) with `GEMINI_API_KEY` set in your `.env`.

**2. Install dependencies:**
```
pip install -r make-debug/requirements.txt
```

**3. Run AI-assisted debugging:**
```
python make-debug/run.py
```
Runs `make`, reads `/tmp/jekyll4500.log`, sends it to the backend, and prints the Gemini response. Pass `--cmd` to use a custom build command.

**4. Run fast local debugging:**
```
python make-debug/log_checker.py
```
Instant regex scan — no backend required.