### PR TITLE
Fix up parallel computing lesson

### DIFF
--- a/_layouts/parallel.html
+++ b/_layouts/parallel.html
@@ -1,11 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Parallel Delivery Game - Learn Parallel Programming</title>
-    <style>
+<style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
@@ -186,8 +179,7 @@
             .storage-content { flex-direction: column; align-items: flex-start; }
         }
     </style>
-</head>
-<body>
+
 <div class="game-container">
     <div class="header">
         <h1>🏭 Warehouse Delivery Challenge</h1>
@@ -1065,6 +1057,3 @@ window.addEventListener('resize', () => { if (!gs.isRunning) drawGame(); });
         </div>
     </div>
 </div>
-
-</body>
-</html>

--- a/_layouts/parallelAndComputinglesson.html
+++ b/_layouts/parallelAndComputinglesson.html
@@ -1,0 +1,1059 @@
+<style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: 'Arial', sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: auto;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-start;
+            align-items: center;
+            padding: 20px;
+        }
+
+        .game-container {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+            max-width: 1400px;
+            width: 100%;
+            padding: 30px;
+            margin-bottom: 40px;
+            margin-top: 20px;
+        }
+
+        .header { text-align: center; margin-bottom: 30px; }
+        .header h1 { color: #333; font-size: 2.5em; margin-bottom: 10px; }
+        .header p { color: #666; font-size: 1.1em; }
+
+        .game-info {
+            display: flex;
+            justify-content: space-around;
+            margin-bottom: 20px;
+            padding: 15px;
+            background: #f5f5f5;
+            border-radius: 10px;
+            flex-wrap: wrap;
+            gap: 15px;
+        }
+
+        .info-item { text-align: center; }
+        .info-label { color: #999; font-size: 0.9em; margin-bottom: 5px; }
+        .info-value { color: #333; font-size: 1.5em; font-weight: bold; }
+
+        .timer { color: #667eea; font-size: 2em; padding: 10px 20px; background: #f0f0f0; border-radius: 8px; }
+        .timer.danger { color: #ff6b6b; }
+        .timer.perfect { color: #51cf66; }
+
+        .storage-section {
+            background: #fff3cd;
+            border: 3px solid #ffc107;
+            border-radius: 10px;
+            padding: 20px;
+            margin-bottom: 20px;
+        }
+
+        .storage-header { font-weight: bold; color: #333; margin-bottom: 10px; font-size: 1.2em; }
+
+        .storage-content { display: flex; align-items: center; gap: 20px; }
+        .storage-count { font-size: 2em; font-weight: bold; color: #ff6b6b; min-width: 50px; }
+        .storage-boxes { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+        .storage-box { width: 30px; height: 30px; background: #ff9800; border: 2px solid #ff8c00; border-radius: 4px; }
+
+        .game-canvas {
+            border: 3px solid #8b7355;
+            border-radius: 10px;
+            overflow: hidden;
+            margin: 20px 0;
+            background: #d4a574;
+            height: 500px;
+            width: 100%;
+            display: block;
+            position: relative;
+        }
+
+        .game-canvas svg { display: block; width: 100%; height: 100%; }
+
+        .lane-controls {
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+            margin-top: 15px;
+            align-items: center;
+        }
+
+        .lane-button {
+            padding: 10px 20px;
+            font-size: 1.2em;
+            border: none;
+            border-radius: 50%;
+            width: 45px;
+            height: 45px;
+            cursor: pointer;
+            font-weight: bold;
+            transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .btn-add-lane { background: #51cf66; color: white; border: 2px solid #40c057; }
+        .btn-add-lane:hover:not(:disabled) { background: #40c057; transform: scale(1.1); }
+        .btn-add-lane:disabled { background: #ddd; color: #999; cursor: not-allowed; }
+
+        .btn-remove-lane { background: #ff6b6b; color: white; border: 2px solid #ff5252; }
+        .btn-remove-lane:hover:not(:disabled) { background: #ff5252; transform: scale(1.1); }
+        .btn-remove-lane:disabled { background: #ddd; color: #999; cursor: not-allowed; }
+
+        .lane-info { text-align: center; color: #333; font-weight: bold; margin-top: 10px; }
+
+        .controls {
+            display: flex;
+            gap: 10px;
+            justify-content: center;
+            margin-top: 20px;
+            flex-wrap: wrap;
+        }
+
+        button {
+            padding: 12px 30px;
+            font-size: 1em;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            font-weight: bold;
+            transition: all 0.3s ease;
+        }
+
+        .btn-primary { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; }
+        .btn-primary:hover:not(:disabled) { transform: translateY(-2px); box-shadow: 0 5px 15px rgba(102,126,234,0.4); }
+        .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+        .btn-secondary { background: white; color: #667eea; border: 2px solid #667eea; }
+        .btn-secondary:hover { background: #f5f7ff; }
+
+        .status {
+            text-align: center;
+            font-size: 1.2em;
+            font-weight: bold;
+            margin: 15px 0;
+            padding: 15px;
+            border-radius: 8px;
+            display: none;
+        }
+        .status.success { background: #d4edda; color: #155724; border: 1px solid #c3e6cb; display: block; }
+        .status.fail { background: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; display: block; }
+
+        .feedback { text-align: center; font-size: 1.1em; color: #666; margin-top: 15px; line-height: 1.6; }
+
+        .score-display {
+            background: #fff3cd;
+            border: 2px solid #ffc107;
+            padding: 15px;
+            border-radius: 8px;
+            margin: 10px 0;
+            font-weight: bold;
+            color: #333;
+        }
+
+        .instructions {
+            background: #f0f7ff;
+            border-left: 4px solid #667eea;
+            padding: 15px;
+            margin-bottom: 20px;
+            border-radius: 5px;
+            color: #333;
+            line-height: 1.6;
+        }
+        .instructions h3 { color: #667eea; margin-bottom: 10px; }
+
+        .stat-perfect { color: #51cf66; font-weight: bold; }
+        .stat-good { color: #ffd43b; font-weight: bold; }
+
+        @media (max-width: 768px) {
+            .game-container { padding: 20px; }
+            .header h1 { font-size: 1.8em; }
+            .game-info { flex-direction: column; gap: 10px; }
+            .game-canvas { height: 350px; }
+            .storage-content { flex-direction: column; align-items: flex-start; }
+        }
+    </style>
+
+<div class="game-container">
+    <div class="header">
+        <h1>🏭 Warehouse Delivery Challenge</h1>
+        <p>Master parallel processing by managing delivery lanes!</p>
+    </div>
+
+    <div class="instructions">
+        <h3>How to Play:</h3>
+        <p>📦 Click the <strong>+</strong> button inside each lane (green button) to load boxes from storage into that lane.</p>
+        <p>🎯 Use the <strong>+</strong> and <strong>−</strong> buttons below to add/remove lanes before starting.</p>
+        <p>▶️ Press <strong>Start Level</strong> to begin — workers will automatically deliver boxes to the trucks!</p>
+        <p>⏱️ Deliver all boxes within 15 seconds. Under 10s = Perfect!</p>
+    </div>
+
+    <div class="game-info">
+        <div class="info-item">
+            <div class="info-label">Level</div>
+            <div class="info-value" id="level-num">1</div>
+        </div>
+        <div class="info-item">
+            <div class="info-label">Time</div>
+            <div class="timer" id="timer">0:00.0</div>
+        </div>
+        <div class="info-item">
+            <div class="info-label">Lanes</div>
+            <div class="info-value" id="lanes-count">1</div>
+        </div>
+        <div class="info-item">
+            <div class="info-label">Delivered</div>
+            <div class="info-value" id="delivered">0</div>
+        </div>
+        <div class="info-item">
+            <div class="info-label">Remaining</div>
+            <div class="info-value" id="remaining">0</div>
+        </div>
+    </div>
+
+    <div class="storage-section">
+        <div class="storage-header">📦 Storage — Available Boxes (click lane's + to load)</div>
+        <div class="storage-content">
+            <div class="storage-count" id="storage-count">0</div>
+            <div class="storage-boxes" id="storage-boxes"></div>
+        </div>
+    </div>
+
+    <div class="game-canvas" id="gameCanvas"></div>
+
+    <div class="lane-controls">
+        <button class="lane-button btn-add-lane" id="addLaneBtn" onclick="addLane()" title="Add Lane">+</button>
+        <div class="lane-info" id="laneInfo">1 lane active (Max: 3)</div>
+        <button class="lane-button btn-remove-lane" id="removeLaneBtn" onclick="removeLane()" title="Remove Lane">−</button>
+    </div>
+
+    <div class="status" id="status"></div>
+    <div class="feedback" id="feedback"></div>
+
+    <div class="controls">
+        <button class="btn-primary" id="startBtn" onclick="startLevel()">▶️ Start Level</button>
+        <button class="btn-secondary" id="nextBtn" onclick="nextLevel()" style="display:none;">Next Level →</button>
+        <button class="btn-secondary" onclick="resetLevel()">🔄 Retry Level</button>
+    </div>
+</div>
+
+<script>
+// ─── CONSTANTS ────────────────────────────────────────────────────────────────
+const CANVAS_HEIGHT    = 500;   // fixed logical height matching CSS
+const LANE_TOP_MARGIN  = 60;
+const LANE_AREA_HEIGHT = 380;
+const WORKER_R         = 14;
+const BOX_W            = 22;
+const BOX_H            = 22;
+const TRUCK_W          = 70;
+const TRUCK_H          = 50;
+const TRUCK_MARGIN     = 10;  // gap from right edge of canvas (logical)
+
+// ─── LEVELS ───────────────────────────────────────────────────────────────────
+const levels = [
+    { number:1, boxCount:3,  initialLanes:1, maxLanes:2, workerSpeed:1,    description:"Sequential Delivery" },
+    { number:2, boxCount:5,  initialLanes:2, maxLanes:3, workerSpeed:1,    description:"Speed Challenge" },
+    { number:3, boxCount:8,  initialLanes:3, maxLanes:4, workerSpeed:1,    description:"Memory Test" },
+    { number:4, boxCount:10, initialLanes:2, maxLanes:5, workerSpeed:1.05, description:"Efficiency Puzzle" },
+    { number:5, boxCount:15, initialLanes:4, maxLanes:6, workerSpeed:1.1,  description:"Master Challenge" }
+];
+
+let currentLevelIndex = 0;
+
+// ─── GAME STATE ───────────────────────────────────────────────────────────────
+let gs = {
+    isRunning      : false,
+    levelStartTime : 0,
+    lanes          : [],
+    boxesDelivered : 0,
+    gameTime       : 0,
+    rafId          : null,
+    totalBoxes     : 0,
+    storageBoxes   : 0,
+    canvasW        : 800   // updated each draw
+};
+
+// ─── LANE CLASS ───────────────────────────────────────────────────────────────
+class Lane {
+    constructor(id, cy, speed) {
+        this.id    = id;
+        this.cy    = cy;           // centre-y of the lane strip
+        this.speed = speed;
+        this.queue = [];           // boxes waiting to be picked up
+        this.state = 'idle';       // idle | toPickup | carrying | returning
+        this.wx    = 0;            // worker x (set in reset)
+        this.wy    = cy;           // worker y
+        this.targetX = 0;
+        this.targetY = cy;
+        this.hasBox  = false;      // is worker carrying a box right now?
+        this.delivered = 0;
+    }
+
+    // Call after lane count changes to reposition lane strip
+    setCY(cy) {
+        this.cy = cy;
+        if (this.state === 'idle') {
+            this.wy      = cy;
+            this.targetY = cy;
+        }
+    }
+
+    // Reset worker to home position (left side of lane)
+    homeX() { return 60; }
+
+    truckDropX(canvasW) {
+        // Worker drops box just left of the truck cargo area
+        return canvasW - TRUCK_MARGIN - TRUCK_W - 5;
+    }
+
+    update(canvasW) {
+        switch (this.state) {
+
+            case 'idle':
+                // Snap to lane centre when idle (handles repositioning)
+                this.wx = this.homeX();
+                this.wy = this.cy;
+                if (this.queue.length > 0) {
+                    // Start walking to pick up first queued box
+                    // Boxes are stacked just to the right of home
+                    this.targetX = this.homeX() + 40;
+                    this.targetY = this.cy;
+                    this.state   = 'toPickup';
+                }
+                break;
+
+            case 'toPickup':
+                if (this._moveTo(this.targetX, this.targetY)) {
+                    // Arrived — grab a box
+                    this.queue.shift();
+                    this.hasBox  = true;
+                    this.targetX = this.truckDropX(canvasW);
+                    this.targetY = this.cy;
+                    this.state   = 'carrying';
+                }
+                break;
+
+            case 'carrying':
+                if (this._moveTo(this.targetX, this.targetY)) {
+                    // Dropped at truck
+                    this.hasBox = false;
+                    this.delivered++;
+                    gs.boxesDelivered++;
+                    this.targetX = this.homeX();
+                    this.targetY = this.cy;
+                    this.state   = 'returning';
+                }
+                break;
+
+            case 'returning':
+                if (this._moveTo(this.targetX, this.targetY)) {
+                    this.state = 'idle';
+                    // Will check queue on next tick
+                }
+                break;
+        }
+    }
+
+    // Move toward (tx,ty) at this.speed. Returns true when arrived.
+    _moveTo(tx, ty) {
+        const dx = tx - this.wx;
+        const dy = ty - this.wy;
+        const dist = Math.sqrt(dx*dx + dy*dy);
+        if (dist <= this.speed) {
+            this.wx = tx;
+            this.wy = ty;
+            return true;
+        }
+        this.wx += (dx / dist) * this.speed;
+        this.wy += (dy / dist) * this.speed;
+        return false;
+    }
+
+    get isBusy() {
+        return this.state !== 'idle';
+    }
+}
+
+// ─── INIT LEVEL ───────────────────────────────────────────────────────────────
+function initLevel() {
+    const lv = levels[currentLevelIndex];
+    cancelAnimationFrame(gs.rafId);
+
+    gs.isRunning      = false;
+    gs.boxesDelivered = 0;
+    gs.gameTime       = 0;
+    gs.totalBoxes     = lv.boxCount;
+    gs.storageBoxes   = lv.boxCount;
+    gs.lanes          = [];
+
+    for (let i = 0; i < lv.initialLanes; i++) {
+        gs.lanes.push(makeLane(i, lv.initialLanes, lv.workerSpeed));
+    }
+
+    // UI resets
+    document.getElementById('status').className   = 'status';
+    document.getElementById('status').textContent = '';
+    document.getElementById('feedback').textContent = '';
+    document.getElementById('nextBtn').style.display = 'none';
+    document.getElementById('startBtn').disabled    = false;
+    document.getElementById('startBtn').textContent = '▶️ Start Level';
+
+    updateLaneButtons();
+    updateUI();
+    drawGame();
+}
+
+function makeLane(id, totalLanes, speed) {
+    const laneH = LANE_AREA_HEIGHT / Math.max(totalLanes, 1);
+    const cy    = LANE_TOP_MARGIN + id * laneH + laneH / 2;
+    const lane  = new Lane(id, cy, 6 * speed);
+    lane.wx     = lane.homeX();
+    lane.wy     = cy;
+    return lane;
+}
+
+function recalcLanePositions() {
+    const total = gs.lanes.length;
+    const laneH = LANE_AREA_HEIGHT / Math.max(total, 1);
+    gs.lanes.forEach((ln, i) => {
+        ln.setCY(LANE_TOP_MARGIN + i * laneH + laneH / 2);
+    });
+}
+
+// ─── LANE ADD / REMOVE ────────────────────────────────────────────────────────
+function addLane() {
+    const lv = levels[currentLevelIndex];
+    if (gs.isRunning || gs.lanes.length >= lv.maxLanes) return;
+    const newId = gs.lanes.length;
+    const total = newId + 1;
+    const laneH = LANE_AREA_HEIGHT / total;
+    const cy    = LANE_TOP_MARGIN + newId * laneH + laneH / 2;
+    const lane  = new Lane(newId, cy, 6 * lv.workerSpeed);
+    lane.wx     = lane.homeX();
+    lane.wy     = cy;
+    gs.lanes.push(lane);
+    recalcLanePositions();
+    updateLaneButtons();
+    updateUI();
+    drawGame();
+}
+
+function removeLane() {
+    if (gs.isRunning || gs.lanes.length <= 1) return;
+    const removed = gs.lanes.pop();
+    // Return undelivered boxes to storage
+    gs.storageBoxes += removed.queue.length;
+    if (removed.hasBox) gs.storageBoxes++;
+    recalcLanePositions();
+    updateLaneButtons();
+    updateUI();
+    drawGame();
+}
+
+// ─── BOX MANAGEMENT ──────────────────────────────────────────────────────────
+function addBoxToLane(laneIdx) {
+    if (gs.isRunning || gs.storageBoxes <= 0) return;
+    if (laneIdx >= gs.lanes.length) return;
+    gs.storageBoxes--;
+    gs.lanes[laneIdx].queue.push({});
+    updateUI();
+    drawGame();
+}
+
+function removeBoxFromLane(laneIdx) {
+    if (gs.isRunning) return;
+    if (laneIdx >= gs.lanes.length) return;
+    if (gs.lanes[laneIdx].queue.length === 0) return;
+    gs.lanes[laneIdx].queue.pop();
+    gs.storageBoxes++;
+    updateUI();
+    drawGame();
+}
+
+// ─── GAME LOOP ────────────────────────────────────────────────────────────────
+function startLevel() {
+    if (gs.isRunning) return;
+    gs.isRunning      = true;
+    gs.levelStartTime = performance.now();
+
+    document.getElementById('startBtn').disabled    = true;
+    document.getElementById('addLaneBtn').disabled  = true;
+    document.getElementById('removeLaneBtn').disabled = true;
+    document.getElementById('status').className     = 'status';
+    document.getElementById('status').textContent   = '';
+    document.getElementById('feedback').textContent = '';
+
+    loop();
+}
+
+function loop() {
+    if (!gs.isRunning) return;
+
+    gs.gameTime = (performance.now() - gs.levelStartTime) / 1000;
+
+    const cw = getCanvasW();
+    gs.lanes.forEach(ln => ln.update(cw));
+
+    const allDelivered = gs.boxesDelivered >= gs.totalBoxes;
+    const allIdle      = gs.lanes.every(ln => !ln.isBusy);
+    const noQueue      = gs.lanes.every(ln => ln.queue.length === 0);
+
+    updateUI();
+    drawGame();
+
+    if (allDelivered && allIdle) {
+        endLevel(true);
+        return;
+    }
+    if (gs.gameTime > 15) {
+        endLevel(false);
+        return;
+    }
+
+    gs.rafId = requestAnimationFrame(loop);
+}
+
+// ─── END LEVEL ───────────────────────────────────────────────────────────────
+function endLevel(success) {
+    gs.isRunning = false;
+    cancelAnimationFrame(gs.rafId);
+
+    const lv      = levels[currentLevelIndex];
+    const t       = gs.gameTime;
+    const statusEl  = document.getElementById('status');
+    const feedbackEl = document.getElementById('feedback');
+
+    if (success) {
+        statusEl.className   = 'status success';
+        statusEl.textContent = '✅ Level Complete!';
+
+        const lanesUsed = gs.lanes.length;
+        let timeBonus = t <= 10 ? 50 : t <= 12 ? 40 : 20;
+        let effBonus  = Math.round(30 * (lv.initialLanes / lanesUsed));
+        let total     = 100 + timeBonus + Math.max(0, effBonus);
+
+        let rating = t <= 10
+            ? `<span class="stat-perfect">Perfect Time! 🚀 ${t.toFixed(1)}s</span>`
+            : t <= 12
+            ? `<span class="stat-good">Great Time! ⚡ ${t.toFixed(1)}s</span>`
+            : `<span class="stat-good">Good Time ✓ ${t.toFixed(1)}s</span>`;
+
+        feedbackEl.innerHTML = rating + `
+            <div class="score-display">
+                📊 Efficiency Score: <strong>${total} points</strong><br>
+                ⏱️ Time Bonus: +${timeBonus} pts<br>
+                👷 Efficiency Bonus: +${Math.max(0, effBonus)} pts<br>
+                🎯 Lanes Used: ${lanesUsed} (started with ${lv.initialLanes})
+            </div>`;
+
+        if (currentLevelIndex < levels.length - 1) {
+            document.getElementById('nextBtn').style.display = 'inline-block';
+        } else {
+            feedbackEl.innerHTML += `<br><span style="color:#667eea;font-weight:bold;display:block;margin-top:10px;">🎉 You've completed all levels!</span>`;
+        }
+    } else {
+        statusEl.className   = 'status fail';
+        statusEl.textContent = '❌ Time\'s Up!';
+        feedbackEl.textContent = `${t.toFixed(1)}s — Too slow! Distribute boxes across more lanes.`;
+    }
+
+    document.getElementById('startBtn').disabled   = false;
+    document.getElementById('startBtn').textContent = '▶️ Try Again';
+    updateLaneButtons();
+}
+
+function nextLevel() {
+    if (currentLevelIndex < levels.length - 1) {
+        currentLevelIndex++;
+        initLevel();
+    }
+}
+
+function resetLevel() {
+    cancelAnimationFrame(gs.rafId);
+    gs.isRunning = false;
+    initLevel();
+}
+
+// ─── UI ───────────────────────────────────────────────────────────────────────
+function updateUI() {
+    const lv = levels[currentLevelIndex];
+    document.getElementById('level-num').textContent  = lv.number;
+    document.getElementById('storage-count').textContent = gs.storageBoxes;
+    document.getElementById('delivered').textContent  = gs.boxesDelivered;
+    document.getElementById('lanes-count').textContent = gs.lanes.length;
+
+    // remaining = boxes not yet delivered (in storage + in queues + being carried)
+    let inTransit = 0;
+    gs.lanes.forEach(ln => {
+        inTransit += ln.queue.length + (ln.hasBox ? 1 : 0);
+    });
+    const remaining = gs.totalBoxes - gs.boxesDelivered;
+    document.getElementById('remaining').textContent = Math.max(0, remaining);
+
+    const m = Math.floor(gs.gameTime / 60);
+    const s = (gs.gameTime % 60).toFixed(1);
+    const timerEl = document.getElementById('timer');
+    timerEl.textContent = `${m}:${s.padStart(4, '0')}`;
+    timerEl.className = 'timer' +
+        (gs.gameTime > 12 ? ' danger' : gs.gameTime >= 0.1 && gs.gameTime <= 10 ? ' perfect' : '');
+
+    // Storage visual
+    const storageDiv = document.getElementById('storage-boxes');
+    storageDiv.innerHTML = '';
+    const show = Math.min(gs.storageBoxes, 10);
+    for (let i = 0; i < show; i++) {
+        const b = document.createElement('div');
+        b.className = 'storage-box';
+        storageDiv.appendChild(b);
+    }
+    if (gs.storageBoxes > 10) {
+        const m2 = document.createElement('div');
+        m2.style.cssText = 'font-size:1.2em;font-weight:bold;color:#333;';
+        m2.textContent = `+${gs.storageBoxes - 10}`;
+        storageDiv.appendChild(m2);
+    }
+}
+
+function updateLaneButtons() {
+    const lv = levels[currentLevelIndex];
+    document.getElementById('addLaneBtn').disabled =
+        gs.isRunning || gs.lanes.length >= lv.maxLanes;
+    document.getElementById('removeLaneBtn').disabled =
+        gs.isRunning || gs.lanes.length <= 1;
+    document.getElementById('laneInfo').textContent =
+        `${gs.lanes.length} lane${gs.lanes.length !== 1 ? 's' : ''} active (Max: ${lv.maxLanes})`;
+}
+
+// ─── DRAWING ─────────────────────────────────────────────────────────────────
+function getCanvasW() {
+    return document.getElementById('gameCanvas').clientWidth || 800;
+}
+
+function drawGame() {
+    const canvas = document.getElementById('gameCanvas');
+    const CW = canvas.clientWidth  || 800;
+    const CH = CANVAS_HEIGHT;
+    gs.canvasW = CW;
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('width',  CW);
+    svg.setAttribute('height', CH);
+    svg.setAttribute('viewBox', `0 0 ${CW} ${CH}`);
+
+    // ── Background ──
+    const bgRect = el(ns, 'rect', { x:0, y:0, width:CW, height:CH, fill:'#d4a574' });
+    svg.appendChild(bgRect);
+
+    // Grid lines
+    for (let gx = 0; gx < CW; gx += 40) {
+        svg.appendChild(el(ns, 'line', { x1:gx, y1:0, x2:gx, y2:CH,
+            stroke:'#c19a6b', 'stroke-width':0.5 }));
+    }
+    for (let gy = 0; gy < CH; gy += 40) {
+        svg.appendChild(el(ns, 'line', { x1:0, y1:gy, x2:CW, y2:gy,
+            stroke:'#c19a6b', 'stroke-width':0.5 }));
+    }
+
+    // ── Per-lane drawing ──
+    gs.lanes.forEach((ln, i) => {
+        const laneH = LANE_AREA_HEIGHT / gs.lanes.length;
+        const top   = ln.cy - laneH / 2 + 4;
+        const h     = laneH - 8;
+
+        // Lane strip
+        svg.appendChild(el(ns, 'rect', {
+            x: 40, y: top,
+            width: CW - 40 - TRUCK_MARGIN - TRUCK_W - 5,
+            height: h,
+            fill:'#e8d7c3', stroke:'#8b7355', 'stroke-width':2, rx:4
+        }));
+
+        // Lane label (top-left of strip)
+        const lbl = el(ns, 'text', {
+            x:48, y: top + 14,
+            fill:'#555', 'font-size':11, 'font-weight':'bold'
+        });
+        lbl.textContent = `Lane ${ln.id + 1}`;
+        svg.appendChild(lbl);
+
+        // ── Truck ──
+        const tx = CW - TRUCK_MARGIN - TRUCK_W;
+        const ty = ln.cy - TRUCK_H / 2;
+        // Cargo body
+        svg.appendChild(el(ns, 'rect', {
+            x:tx, y:ty, width:TRUCK_W - 18, height:TRUCK_H,
+            fill:'#ff6b6b', stroke:'#cc0000', 'stroke-width':2, rx:2
+        }));
+        // Cab
+        svg.appendChild(el(ns, 'rect', {
+            x: tx + TRUCK_W - 20, y: ty + 4,
+            width:16, height: TRUCK_H - 8,
+            fill:'#cc4444', stroke:'#aa0000', 'stroke-width':1, rx:2
+        }));
+        // Windshield
+        svg.appendChild(el(ns, 'rect', {
+            x: tx + TRUCK_W - 18, y: ty + 7,
+            width:10, height:10,
+            fill:'#aaddff', rx:1
+        }));
+        // Wheels
+        [-4, TRUCK_H - 8].forEach(wy => {
+            svg.appendChild(el(ns, 'circle', {
+                cx: tx + 10, cy: ty + TRUCK_H + wy/2 + 2, r:5,
+                fill:'#333'
+            }));
+            svg.appendChild(el(ns, 'circle', {
+                cx: tx + TRUCK_W - 24, cy: ty + TRUCK_H + wy/2 + 2, r:5,
+                fill:'#333'
+            }));
+        });
+        // Truck number
+        const tn = el(ns, 'text', {
+            x: tx + (TRUCK_W - 18) / 2, y: ln.cy + 5,
+            'text-anchor':'middle', fill:'white', 'font-size':12, 'font-weight':'bold'
+        });
+        tn.textContent = `T${i+1}`;
+        svg.appendChild(tn);
+
+        // ── Queued boxes (stacked left of pickup point) ──
+        const queueStartX = ln.homeX() + 45;
+        const maxShow = Math.min(ln.queue.length, 5);
+        for (let q = 0; q < maxShow; q++) {
+            svg.appendChild(el(ns, 'rect', {
+                x: queueStartX + q * (BOX_W + 4),
+                y: ln.cy - BOX_H / 2,
+                width: BOX_W, height: BOX_H,
+                fill:'#ff9800', stroke:'#e65c00', 'stroke-width':1.5, rx:2
+            }));
+        }
+        if (ln.queue.length > 5) {
+            const qMore = el(ns, 'text', {
+                x: queueStartX + 5 * (BOX_W + 4) + 4,
+                y: ln.cy + 5,
+                fill:'#e65c00', 'font-size':11, 'font-weight':'bold'
+            });
+            qMore.textContent = `+${ln.queue.length - 5}`;
+            svg.appendChild(qMore);
+        }
+
+        // Queue count badge
+        if (ln.queue.length > 0) {
+            const badge = el(ns, 'text', {
+                x: queueStartX - 4,
+                y: ln.cy - BOX_H / 2 - 4,
+                fill:'#333', 'font-size':10, 'font-weight':'bold'
+            });
+            badge.textContent = `${ln.queue.length} box${ln.queue.length !== 1 ? 'es' : ''}`;
+            svg.appendChild(badge);
+        }
+
+        // ── Worker ──
+        const workerColor = ln.state === 'idle' ? '#aaa'
+            : ln.state === 'carrying' ? '#51cf66'
+            : '#667eea';
+
+        // Shadow
+        svg.appendChild(el(ns, 'ellipse', {
+            cx: ln.wx, cy: ln.wy + WORKER_R + 2,
+            rx: WORKER_R, ry: 4,
+            fill:'rgba(0,0,0,0.15)'
+        }));
+        // Body
+        svg.appendChild(el(ns, 'circle', {
+            cx: ln.wx, cy: ln.wy,
+            r: WORKER_R,
+            fill: workerColor, stroke:'#fff', 'stroke-width':2
+        }));
+        // Hardhat
+        svg.appendChild(el(ns, 'rect', {
+            x: ln.wx - 9, y: ln.wy - WORKER_R - 4,
+            width:18, height:7,
+            fill:'#ffc107', rx:3
+        }));
+
+        // Carried box (above worker)
+        if (ln.hasBox) {
+            svg.appendChild(el(ns, 'rect', {
+                x: ln.wx - BOX_W / 2,
+                y: ln.wy - WORKER_R - BOX_H - 2,
+                width: BOX_W, height: BOX_H,
+                fill:'#ff9800', stroke:'#e65c00', 'stroke-width':1.5, rx:2
+            }));
+        }
+
+        // ── In-lane + / − buttons (only when not running) ──
+        if (!gs.isRunning) {
+            // + button
+            const plusX = 50;
+            const plusY = ln.cy;
+            const plusBg = el(ns, 'rect', {
+                x: plusX - 10, y: plusY - 10,
+                width:20, height:20,
+                fill: gs.storageBoxes > 0 ? '#51cf66' : '#ccc',
+                rx:4, stroke:'#fff', 'stroke-width':1,
+                style: gs.storageBoxes > 0 ? 'cursor:pointer' : 'cursor:not-allowed'
+            });
+            plusBg.addEventListener('click', () => addBoxToLane(i));
+            svg.appendChild(plusBg);
+
+            const plusTxt = el(ns, 'text', {
+                x: plusX, y: plusY + 5,
+                'text-anchor':'middle', fill:'white',
+                'font-size':16, 'font-weight':'bold',
+                'pointer-events':'none'
+            });
+            plusTxt.textContent = '+';
+            svg.appendChild(plusTxt);
+
+            // − button (only if boxes in queue)
+            if (ln.queue.length > 0) {
+                const minX = plusX + 24;
+                const minBg = el(ns, 'rect', {
+                    x: minX - 10, y: plusY - 10,
+                    width:20, height:20,
+                    fill:'#ff6b6b',
+                    rx:4, stroke:'#fff', 'stroke-width':1,
+                    style:'cursor:pointer'
+                });
+                minBg.addEventListener('click', () => removeBoxFromLane(i));
+                svg.appendChild(minBg);
+
+                const minTxt = el(ns, 'text', {
+                    x: minX, y: plusY + 5,
+                    'text-anchor':'middle', fill:'white',
+                    'font-size':18, 'font-weight':'bold',
+                    'pointer-events':'none'
+                });
+                minTxt.textContent = '−';
+                svg.appendChild(minTxt);
+            }
+        }
+    });
+
+    // ── Progress bar ──
+    const progressW = CW - 40;
+    const progressH = 12;
+    const progressY = CH - 25;
+    const progressX = 20;
+    svg.appendChild(el(ns, 'rect', {
+        x:progressX, y:progressY,
+        width:progressW, height:progressH,
+        fill:'#e0e0e0', rx:6
+    }));
+    const pct = gs.totalBoxes > 0 ? gs.boxesDelivered / gs.totalBoxes : 0;
+    if (pct > 0) {
+        svg.appendChild(el(ns, 'rect', {
+            x:progressX, y:progressY,
+            width: progressW * pct, height:progressH,
+            fill:'#51cf66', rx:6
+        }));
+    }
+    const progLabel = el(ns, 'text', {
+        x: CW / 2, y: progressY + 9,
+        'text-anchor':'middle', fill:'#333', 'font-size':9, 'font-weight':'bold'
+    });
+    progLabel.textContent = `${gs.boxesDelivered} / ${gs.totalBoxes} delivered`;
+    svg.appendChild(progLabel);
+
+    canvas.innerHTML = '';
+    canvas.appendChild(svg);
+}
+
+// Helper: create SVG element with attributes
+function el(ns, tag, attrs) {
+    const e = document.createElementNS(ns, tag);
+    for (const [k, v] of Object.entries(attrs)) {
+        e.setAttribute(k, v);
+    }
+    return e;
+}
+
+// ─── BOOT ─────────────────────────────────────────────────────────────────────
+window.addEventListener('load', () => initLevel());
+window.addEventListener('resize', () => { if (!gs.isRunning) drawGame(); });
+</script>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     LESSON SECTION
+     ═══════════════════════════════════════════════════════════════════════════ -->
+<style>
+    .lesson-container {
+        background: white;
+        padding: 40px 20px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        margin-top: 20px;
+    }
+
+    .lesson-wrapper {
+        background: white;
+        border-radius: 20px;
+        box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+        max-width: 1200px;
+        width: 100%;
+        padding: 40px;
+    }
+
+    .lesson-title { text-align:center; color:#333; font-size:2.2em; margin-bottom:10px; font-weight:bold; }
+    .lesson-subtitle { text-align:center; color:#666; font-size:1.1em; margin-bottom:40px; }
+
+    .lesson-section { margin-bottom:40px; display:flex; gap:30px; align-items:center; flex-wrap:wrap; }
+    .lesson-text { flex:1; min-width:300px; }
+    .lesson-text h3 { color:#667eea; font-size:1.5em; margin-bottom:15px; }
+    .lesson-text p { color:#555; font-size:1em; line-height:1.8; margin-bottom:12px; }
+    .lesson-visual { flex:1; min-width:300px; display:flex; justify-content:center; }
+
+    .comparison-box {
+        background:#f5f7ff; border-left:4px solid #667eea;
+        padding:20px; border-radius:8px; margin:15px 0;
+    }
+    .comparison-item { display:flex; gap:15px; margin:12px 0; align-items:center; }
+    .comparison-label { font-weight:bold; color:#333; min-width:100px; }
+    .comparison-value { color:#667eea; font-weight:bold; font-size:1.1em; }
+
+    .speedup-visualizer { display:flex; gap:30px; margin:30px 0; align-items:flex-end; }
+    .bar-group { flex:1; text-align:center; }
+    .bar-group h4 { margin-bottom:10px; color:#333; }
+    .bar-group .label { font-size:0.9em; color:#666; margin-bottom:5px; }
+    .speed-bar { width:100%; border-radius:5px; margin-bottom:8px; display:flex; align-items:center; justify-content:center; color:white; font-weight:bold; }
+    .bar-sequential { background:linear-gradient(90deg,#ff6b6b,#ff5252); height:40px; }
+    .bar-parallel { background:linear-gradient(90deg,#51cf66,#40c057); height:90px; }
+
+    .key-points { background:#f0f7ff; border-left:4px solid #667eea; padding:20px; border-radius:8px; margin:20px 0; }
+    .key-points h4 { color:#667eea; margin-bottom:12px; }
+    .key-points ul { list-style:none; padding:0; }
+    .key-points li { padding:8px 0; color:#555; border-bottom:1px solid #e0e7ff; }
+    .key-points li:before { content:"✓ "; color:#667eea; font-weight:bold; margin-right:8px; }
+    .key-points li:last-child { border-bottom:none; }
+
+    .divider { height:2px; background:linear-gradient(90deg,transparent 0%,#667eea 50%,transparent 100%); margin:40px 0; }
+
+    @media (max-width:768px) {
+        .lesson-wrapper { padding:25px; }
+        .lesson-title { font-size:1.8em; }
+        .lesson-section { gap:20px; }
+        .speedup-visualizer { flex-direction:column; gap:20px; }
+    }
+</style>
+
+<div class="lesson-container">
+    <div class="lesson-wrapper">
+        <h1 class="lesson-title">📚 Understanding Parallel Computing</h1>
+        <p class="lesson-subtitle">How workers run faster together</p>
+
+        <div class="lesson-section">
+            <div class="lesson-text">
+                <h3>🤔 What's Parallel Computing?</h3>
+                <p>Parallel computing means breaking a big task into smaller pieces and working on them <strong>at the same time</strong> instead of one after another.</p>
+                <p>In the warehouse game:</p>
+                <div class="comparison-box">
+                    <div class="comparison-item"><span class="comparison-label">Sequential:</span><span>1 worker delivers ALL boxes alone</span></div>
+                    <div class="comparison-item"><span class="comparison-label">Parallel:</span><span>Many workers deliver boxes together</span></div>
+                </div>
+                <p><strong>Result:</strong> Parallel is MUCH faster! ⚡</p>
+            </div>
+            <div class="lesson-visual">
+                <svg width="300" height="200" viewBox="0 0 300 200" style="background:#f5f7ff;border-radius:10px;">
+                    <text x="75" y="25" font-weight="bold" font-size="14" text-anchor="middle">Sequential</text>
+                    <circle cx="75" cy="60" r="15" fill="#667eea"/>
+                    <line x1="75" y1="75" x2="75" y2="110" stroke="#ddd" stroke-width="2" stroke-dasharray="5,5"/>
+                    <rect x="55" y="115" width="40" height="30" fill="#ff9800" stroke="#ff8c00" stroke-width="2"/>
+                    <text x="75" y="175" font-size="12" text-anchor="middle" fill="#666">Takes longer</text>
+                    <text x="225" y="25" font-weight="bold" font-size="14" text-anchor="middle">Parallel</text>
+                    <circle cx="205" cy="60" r="12" fill="#51cf66"/>
+                    <circle cx="225" cy="60" r="12" fill="#51cf66"/>
+                    <circle cx="245" cy="60" r="12" fill="#51cf66"/>
+                    <line x1="205" y1="75" x2="205" y2="110" stroke="#ddd" stroke-width="2" stroke-dasharray="5,5"/>
+                    <line x1="225" y1="75" x2="225" y2="110" stroke="#ddd" stroke-width="2" stroke-dasharray="5,5"/>
+                    <line x1="245" y1="75" x2="245" y2="110" stroke="#ddd" stroke-width="2" stroke-dasharray="5,5"/>
+                    <rect x="185" y="115" width="40" height="30" fill="#ff9800" stroke="#ff8c00" stroke-width="2"/>
+                    <text x="225" y="175" font-size="12" text-anchor="middle" fill="#51cf66" font-weight="bold">Much faster! ⚡</text>
+                </svg>
+            </div>
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="lesson-section">
+            <div class="lesson-text">
+                <h3>⚡ The Speedup Effect</h3>
+                <p>When you add more workers (processors), tasks complete faster. This is called <strong>speedup</strong>.</p>
+                <div class="key-points">
+                    <h4>Key Insight</h4>
+                    <ul>
+                        <li>1 worker = baseline time</li>
+                        <li>2 workers = roughly 2x faster</li>
+                        <li>4 workers = roughly 4x faster</li>
+                    </ul>
+                </div>
+                <p><strong>But there's a limit!</strong> At some point, adding more workers won't help (coordination overhead).</p>
+            </div>
+            <div class="lesson-visual">
+                <div class="speedup-visualizer">
+                    <div class="bar-group">
+                        <h4>Sequential</h4>
+                        <div class="label">1 worker</div>
+                        <div class="speed-bar bar-sequential">100%</div>
+                    </div>
+                    <div class="bar-group">
+                        <h4>Parallel</h4>
+                        <div class="label">4 workers</div>
+                        <div class="speed-bar bar-parallel">4x faster</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="lesson-section">
+            <div class="lesson-text">
+                <h3>🌍 Real-World Parallel Computing</h3>
+                <p>Parallel computing is everywhere in modern technology:</p>
+                <div class="comparison-box"><strong>GPU Graphics:</strong> Thousands of tiny processors work on pixels simultaneously</div>
+                <div class="comparison-box"><strong>Web Servers:</strong> Handle thousands of user requests in parallel</div>
+                <div class="comparison-box"><strong>Video Processing:</strong> Process frames in parallel for faster rendering</div>
+                <div class="comparison-box"><strong>Data Analysis:</strong> Analyze huge datasets faster by splitting work across cores</div>
+            </div>
+            <div class="lesson-visual">
+                <svg width="300" height="280" viewBox="0 0 300 280" style="background:#f5f7ff;border-radius:10px;">
+                    <text x="150" y="25" font-weight="bold" font-size="14" text-anchor="middle">Modern CPU: 8 Cores</text>
+                    <rect x="30"  y="50"  width="50" height="50" fill="#667eea" stroke="#5568d3" stroke-width="2"/><text x="55"  y="82" text-anchor="middle" fill="white" font-weight="bold">C1</text>
+                    <rect x="90"  y="50"  width="50" height="50" fill="#667eea" stroke="#5568d3" stroke-width="2"/><text x="115" y="82" text-anchor="middle" fill="white" font-weight="bold">C2</text>
+                    <rect x="150" y="50"  width="50" height="50" fill="#667eea" stroke="#5568d3" stroke-width="2"/><text x="175" y="82" text-anchor="middle" fill="white" font-weight="bold">C3</text>
+                    <rect x="210" y="50"  width="50" height="50" fill="#667eea" stroke="#5568d3" stroke-width="2"/><text x="235" y="82" text-anchor="middle" fill="white" font-weight="bold">C4</text>
+                    <rect x="30"  y="110" width="50" height="50" fill="#51cf66" stroke="#40c057" stroke-width="2"/><text x="55"  y="142" text-anchor="middle" fill="white" font-weight="bold">C5</text>
+                    <rect x="90"  y="110" width="50" height="50" fill="#51cf66" stroke="#40c057" stroke-width="2"/><text x="115" y="142" text-anchor="middle" fill="white" font-weight="bold">C6</text>
+                    <rect x="150" y="110" width="50" height="50" fill="#51cf66" stroke="#40c057" stroke-width="2"/><text x="175" y="142" text-anchor="middle" fill="white" font-weight="bold">C7</text>
+                    <rect x="210" y="110" width="50" height="50" fill="#51cf66" stroke="#40c057" stroke-width="2"/><text x="235" y="142" text-anchor="middle" fill="white" font-weight="bold">C8</text>
+                    <text x="150" y="190" text-anchor="middle" font-size="12" fill="#666">All running tasks</text>
+                    <text x="150" y="210" text-anchor="middle" font-size="12" fill="#666">at the SAME TIME</text>
+                    <text x="150" y="250" text-anchor="middle" font-size="14" font-weight="bold" fill="#51cf66">🚀 That's parallel!</text>
+                </svg>
+            </div>
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="key-points">
+            <h4>💡 Key Takeaways</h4>
+            <ul>
+                <li>Parallel computing breaks big tasks into smaller ones</li>
+                <li>Multiple processors work on different tasks simultaneously</li>
+                <li>This creates significant speedup in execution time</li>
+                <li>Real-world examples: GPUs, servers, video games, data processing</li>
+                <li>Not all problems can be easily parallelized (some tasks depend on each other)</li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/_projects/parallelAndComputinglesson/Makefile
+++ b/_projects/parallelAndComputinglesson/Makefile
@@ -24,7 +24,7 @@ JS_DEST = $(WORKSPACE_ROOT)/assets/js/projects/$(PROJECT_NAME)
 IMAGES_DEST = $(WORKSPACE_ROOT)/images/projects/$(PROJECT_NAME)
 NOTEBOOK_DEST = $(WORKSPACE_ROOT)/_notebooks/projects/$(PROJECT_NAME)
 DOCS_DEST = $(WORKSPACE_ROOT)/_posts/projects/$(PROJECT_NAME)
-HTML_DEST = $(WORKSPACE_ROOT)/assets/html/projects/$(PROJECT_NAME)
+LAYOUT_DEST = $(WORKSPACE_ROOT)/_layouts
 
 ###########################################
 # Build Targets
@@ -42,7 +42,7 @@ build:
 	@echo "   Notebooks: _notebooks/projects/$(PROJECT_NAME)/"
 	@echo "   JavaScript: assets/js/projects/$(PROJECT_NAME)/"
 	@echo "   Images: images/projects/$(PROJECT_NAME)/"
-	@echo "   HTML Lessons: assets/html/projects/$(PROJECT_NAME)/"
+	@echo "   Layouts: _layouts/parallelAndComputinglesson.html"
 
 # Copy only JS and image assets (not notebook) - for watch triggers
 assets:
@@ -52,9 +52,8 @@ assets:
 	@if [ -d model ] && [ "$$(ls -A model/*.js 2>/dev/null)" ]; then cp model/*.js $(JS_DEST)/model/ && echo "✓ Copied model JS"; fi
 	@mkdir -p $(IMAGES_DEST)
 	@if [ -d images ] && [ "$$(ls -A images 2>/dev/null)" ]; then cp -r images/* $(IMAGES_DEST)/ && echo "✓ Copied images"; fi
-	@mkdir -p $(HTML_DEST)
-	@if [ -f index.html ]; then cp index.html $(HTML_DEST)/ && echo "✓ Copied index.html"; fi
-	@if [ -f parallel.html ]; then cp parallel.html $(HTML_DEST)/ && echo "✓ Copied parallel.html"; fi
+	@mkdir -p $(LAYOUT_DEST)
+	@if [ -f parallelAndComputinglesson.html ]; then cp parallelAndComputinglesson.html $(LAYOUT_DEST)/parallelAndComputinglesson.html && echo "✓ Copied parallel computing lesson layout to _layouts"; fi
 
 # Clean distributed files (keeps source intact)
 clean:
@@ -62,7 +61,7 @@ clean:
 	@rm -rf $(NOTEBOOK_DEST)
 	@rm -rf $(JS_DEST)
 	@rm -rf $(IMAGES_DEST)
-	@rm -rf $(HTML_DEST)
+	@rm -f $(LAYOUT_DEST)/parallelAndComputinglesson.html
 	@echo "✓ Distribution cleaned (source files preserved in _projects/$(PROJECT_NAME))"
 
 ###########################################
@@ -102,6 +101,10 @@ watch:
 			elif echo "$$changed_file" | grep -q "/images/"; then \
 				echo "  🔄 Images changed - copying all images..."; \
 				$(MAKE) assets 2>&1 | grep -v "cp:" | head -1; \
+			elif echo "$$changed_file" | grep -q "parallelAndComputinglesson.html"; then \
+				echo "  🔄 Layout changed - copying to _layouts..."; \
+				mkdir -p $(LAYOUT_DEST); \
+				cp "$$changed_file" $(LAYOUT_DEST)/parallelAndComputinglesson.html 2>/dev/null || true; \
 			else \
 				echo "  🔄 File changed: $$changed_file (copying all assets)"; \
 				$(MAKE) assets 2>&1 | grep -v "cp:"; \

--- a/_projects/parallelAndComputinglesson/docs/lesson.md
+++ b/_projects/parallelAndComputinglesson/docs/lesson.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: parallelAndComputinglesson
 title: "Slackers Learning Parallel: Interactive Lesson"
 date: 2026-04-24
 categories: ['cs-fundamentals', 'parallel-computing']
@@ -8,31 +8,3 @@ author: CS Educators
 description: "An engaging, interactive 2-2.5 minute lesson on parallel processing and multi-threaded execution for CS students"
 permalink: /lessons/slackers/parrallel/
 ---
-
-# 🏭 Warehouse Delivery Challenge - Learn Parallel Computing
-
-## Interactive Lesson on Parallel Processing
-
-Experience parallel computing hands-on with our interactive warehouse delivery game!
-
-**[👉 Click here to play the interactive lesson →]({{ site.baseurl }}/assets/html/projects/parallelAndComputinglesson/parallel.html)**
-
-### What You'll Learn:
-
-✅ **How parallel processing works** - Managing multiple delivery lanes simultaneously  
-✅ **The speedup effect** - How more workers make tasks complete faster  
-✅ **Real-world applications** - GPUs, web servers, and data processing  
-✅ **Efficiency vs performance** - Balancing resources for optimal results
-
-### The Game:
-
-Start with **1 worker** delivering boxes sequentially. As you progress:
-- **Level 1:** Learn sequential delivery with a single worker
-- **Level 2:** Discover parallel delivery with 2 workers
-- **Level 3:** Master full parallelism with 4 workers
-
-Add and remove lanes to control how many workers operate in parallel. Try to deliver all boxes in **10-15 seconds** for the best score!
-
----
-
-**Duration:** ~2-2.5 minutes of hands-on learning + interactive exploration

--- a/_projects/parallelAndComputinglesson/parallelAndComputinglesson.html
+++ b/_projects/parallelAndComputinglesson/parallelAndComputinglesson.html
@@ -1,0 +1,1059 @@
+<style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: 'Arial', sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: auto;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-start;
+            align-items: center;
+            padding: 20px;
+        }
+
+        .game-container {
+            background: white;
+            border-radius: 20px;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+            max-width: 1400px;
+            width: 100%;
+            padding: 30px;
+            margin-bottom: 40px;
+            margin-top: 20px;
+        }
+
+        .header { text-align: center; margin-bottom: 30px; }
+        .header h1 { color: #333; font-size: 2.5em; margin-bottom: 10px; }
+        .header p { color: #666; font-size: 1.1em; }
+
+        .game-info {
+            display: flex;
+            justify-content: space-around;
+            margin-bottom: 20px;
+            padding: 15px;
+            background: #f5f5f5;
+            border-radius: 10px;
+            flex-wrap: wrap;
+            gap: 15px;
+        }
+
+        .info-item { text-align: center; }
+        .info-label { color: #999; font-size: 0.9em; margin-bottom: 5px; }
+        .info-value { color: #333; font-size: 1.5em; font-weight: bold; }
+
+        .timer { color: #667eea; font-size: 2em; padding: 10px 20px; background: #f0f0f0; border-radius: 8px; }
+        .timer.danger { color: #ff6b6b; }
+        .timer.perfect { color: #51cf66; }
+
+        .storage-section {
+            background: #fff3cd;
+            border: 3px solid #ffc107;
+            border-radius: 10px;
+            padding: 20px;
+            margin-bottom: 20px;
+        }
+
+        .storage-header { font-weight: bold; color: #333; margin-bottom: 10px; font-size: 1.2em; }
+
+        .storage-content { display: flex; align-items: center; gap: 20px; }
+        .storage-count { font-size: 2em; font-weight: bold; color: #ff6b6b; min-width: 50px; }
+        .storage-boxes { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+        .storage-box { width: 30px; height: 30px; background: #ff9800; border: 2px solid #ff8c00; border-radius: 4px; }
+
+        .game-canvas {
+            border: 3px solid #8b7355;
+            border-radius: 10px;
+            overflow: hidden;
+            margin: 20px 0;
+            background: #d4a574;
+            height: 500px;
+            width: 100%;
+            display: block;
+            position: relative;
+        }
+
+        .game-canvas svg { display: block; width: 100%; height: 100%; }
+
+        .lane-controls {
+            display: flex;
+            justify-content: center;
+            gap: 15px;
+            margin-top: 15px;
+            align-items: center;
+        }
+
+        .lane-button {
+            padding: 10px 20px;
+            font-size: 1.2em;
+            border: none;
+            border-radius: 50%;
+            width: 45px;
+            height: 45px;
+            cursor: pointer;
+            font-weight: bold;
+            transition: all 0.3s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .btn-add-lane { background: #51cf66; color: white; border: 2px solid #40c057; }
+        .btn-add-lane:hover:not(:disabled) { background: #40c057; transform: scale(1.1); }
+        .btn-add-lane:disabled { background: #ddd; color: #999; cursor: not-allowed; }
+
+        .btn-remove-lane { background: #ff6b6b; color: white; border: 2px solid #ff5252; }
+        .btn-remove-lane:hover:not(:disabled) { background: #ff5252; transform: scale(1.1); }
+        .btn-remove-lane:disabled { background: #ddd; color: #999; cursor: not-allowed; }
+
+        .lane-info { text-align: center; color: #333; font-weight: bold; margin-top: 10px; }
+
+        .controls {
+            display: flex;
+            gap: 10px;
+            justify-content: center;
+            margin-top: 20px;
+            flex-wrap: wrap;
+        }
+
+        button {
+            padding: 12px 30px;
+            font-size: 1em;
+            border: none;
+            border-radius: 8px;
+            cursor: pointer;
+            font-weight: bold;
+            transition: all 0.3s ease;
+        }
+
+        .btn-primary { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; }
+        .btn-primary:hover:not(:disabled) { transform: translateY(-2px); box-shadow: 0 5px 15px rgba(102,126,234,0.4); }
+        .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+        .btn-secondary { background: white; color: #667eea; border: 2px solid #667eea; }
+        .btn-secondary:hover { background: #f5f7ff; }
+
+        .status {
+            text-align: center;
+            font-size: 1.2em;
+            font-weight: bold;
+            margin: 15px 0;
+            padding: 15px;
+            border-radius: 8px;
+            display: none;
+        }
+        .status.success { background: #d4edda; color: #155724; border: 1px solid #c3e6cb; display: block; }
+        .status.fail { background: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; display: block; }
+
+        .feedback { text-align: center; font-size: 1.1em; color: #666; margin-top: 15px; line-height: 1.6; }
+
+        .score-display {
+            background: #fff3cd;
+            border: 2px solid #ffc107;
+            padding: 15px;
+            border-radius: 8px;
+            margin: 10px 0;
+            font-weight: bold;
+            color: #333;
+        }
+
+        .instructions {
+            background: #f0f7ff;
+            border-left: 4px solid #667eea;
+            padding: 15px;
+            margin-bottom: 20px;
+            border-radius: 5px;
+            color: #333;
+            line-height: 1.6;
+        }
+        .instructions h3 { color: #667eea; margin-bottom: 10px; }
+
+        .stat-perfect { color: #51cf66; font-weight: bold; }
+        .stat-good { color: #ffd43b; font-weight: bold; }
+
+        @media (max-width: 768px) {
+            .game-container { padding: 20px; }
+            .header h1 { font-size: 1.8em; }
+            .game-info { flex-direction: column; gap: 10px; }
+            .game-canvas { height: 350px; }
+            .storage-content { flex-direction: column; align-items: flex-start; }
+        }
+    </style>
+
+<div class="game-container">
+    <div class="header">
+        <h1>🏭 Warehouse Delivery Challenge</h1>
+        <p>Master parallel processing by managing delivery lanes!</p>
+    </div>
+
+    <div class="instructions">
+        <h3>How to Play:</h3>
+        <p>📦 Click the <strong>+</strong> button inside each lane (green button) to load boxes from storage into that lane.</p>
+        <p>🎯 Use the <strong>+</strong> and <strong>−</strong> buttons below to add/remove lanes before starting.</p>
+        <p>▶️ Press <strong>Start Level</strong> to begin — workers will automatically deliver boxes to the trucks!</p>
+        <p>⏱️ Deliver all boxes within 15 seconds. Under 10s = Perfect!</p>
+    </div>
+
+    <div class="game-info">
+        <div class="info-item">
+            <div class="info-label">Level</div>
+            <div class="info-value" id="level-num">1</div>
+        </div>
+        <div class="info-item">
+            <div class="info-label">Time</div>
+            <div class="timer" id="timer">0:00.0</div>
+        </div>
+        <div class="info-item">
+            <div class="info-label">Lanes</div>
+            <div class="info-value" id="lanes-count">1</div>
+        </div>
+        <div class="info-item">
+            <div class="info-label">Delivered</div>
+            <div class="info-value" id="delivered">0</div>
+        </div>
+        <div class="info-item">
+            <div class="info-label">Remaining</div>
+            <div class="info-value" id="remaining">0</div>
+        </div>
+    </div>
+
+    <div class="storage-section">
+        <div class="storage-header">📦 Storage — Available Boxes (click lane's + to load)</div>
+        <div class="storage-content">
+            <div class="storage-count" id="storage-count">0</div>
+            <div class="storage-boxes" id="storage-boxes"></div>
+        </div>
+    </div>
+
+    <div class="game-canvas" id="gameCanvas"></div>
+
+    <div class="lane-controls">
+        <button class="lane-button btn-add-lane" id="addLaneBtn" onclick="addLane()" title="Add Lane">+</button>
+        <div class="lane-info" id="laneInfo">1 lane active (Max: 3)</div>
+        <button class="lane-button btn-remove-lane" id="removeLaneBtn" onclick="removeLane()" title="Remove Lane">−</button>
+    </div>
+
+    <div class="status" id="status"></div>
+    <div class="feedback" id="feedback"></div>
+
+    <div class="controls">
+        <button class="btn-primary" id="startBtn" onclick="startLevel()">▶️ Start Level</button>
+        <button class="btn-secondary" id="nextBtn" onclick="nextLevel()" style="display:none;">Next Level →</button>
+        <button class="btn-secondary" onclick="resetLevel()">🔄 Retry Level</button>
+    </div>
+</div>
+
+<script>
+// ─── CONSTANTS ────────────────────────────────────────────────────────────────
+const CANVAS_HEIGHT    = 500;   // fixed logical height matching CSS
+const LANE_TOP_MARGIN  = 60;
+const LANE_AREA_HEIGHT = 380;
+const WORKER_R         = 14;
+const BOX_W            = 22;
+const BOX_H            = 22;
+const TRUCK_W          = 70;
+const TRUCK_H          = 50;
+const TRUCK_MARGIN     = 10;  // gap from right edge of canvas (logical)
+
+// ─── LEVELS ───────────────────────────────────────────────────────────────────
+const levels = [
+    { number:1, boxCount:3,  initialLanes:1, maxLanes:2, workerSpeed:1,    description:"Sequential Delivery" },
+    { number:2, boxCount:5,  initialLanes:2, maxLanes:3, workerSpeed:1,    description:"Speed Challenge" },
+    { number:3, boxCount:8,  initialLanes:3, maxLanes:4, workerSpeed:1,    description:"Memory Test" },
+    { number:4, boxCount:10, initialLanes:2, maxLanes:5, workerSpeed:1.05, description:"Efficiency Puzzle" },
+    { number:5, boxCount:15, initialLanes:4, maxLanes:6, workerSpeed:1.1,  description:"Master Challenge" }
+];
+
+let currentLevelIndex = 0;
+
+// ─── GAME STATE ───────────────────────────────────────────────────────────────
+let gs = {
+    isRunning      : false,
+    levelStartTime : 0,
+    lanes          : [],
+    boxesDelivered : 0,
+    gameTime       : 0,
+    rafId          : null,
+    totalBoxes     : 0,
+    storageBoxes   : 0,
+    canvasW        : 800   // updated each draw
+};
+
+// ─── LANE CLASS ───────────────────────────────────────────────────────────────
+class Lane {
+    constructor(id, cy, speed) {
+        this.id    = id;
+        this.cy    = cy;           // centre-y of the lane strip
+        this.speed = speed;
+        this.queue = [];           // boxes waiting to be picked up
+        this.state = 'idle';       // idle | toPickup | carrying | returning
+        this.wx    = 0;            // worker x (set in reset)
+        this.wy    = cy;           // worker y
+        this.targetX = 0;
+        this.targetY = cy;
+        this.hasBox  = false;      // is worker carrying a box right now?
+        this.delivered = 0;
+    }
+
+    // Call after lane count changes to reposition lane strip
+    setCY(cy) {
+        this.cy = cy;
+        if (this.state === 'idle') {
+            this.wy      = cy;
+            this.targetY = cy;
+        }
+    }
+
+    // Reset worker to home position (left side of lane)
+    homeX() { return 60; }
+
+    truckDropX(canvasW) {
+        // Worker drops box just left of the truck cargo area
+        return canvasW - TRUCK_MARGIN - TRUCK_W - 5;
+    }
+
+    update(canvasW) {
+        switch (this.state) {
+
+            case 'idle':
+                // Snap to lane centre when idle (handles repositioning)
+                this.wx = this.homeX();
+                this.wy = this.cy;
+                if (this.queue.length > 0) {
+                    // Start walking to pick up first queued box
+                    // Boxes are stacked just to the right of home
+                    this.targetX = this.homeX() + 40;
+                    this.targetY = this.cy;
+                    this.state   = 'toPickup';
+                }
+                break;
+
+            case 'toPickup':
+                if (this._moveTo(this.targetX, this.targetY)) {
+                    // Arrived — grab a box
+                    this.queue.shift();
+                    this.hasBox  = true;
+                    this.targetX = this.truckDropX(canvasW);
+                    this.targetY = this.cy;
+                    this.state   = 'carrying';
+                }
+                break;
+
+            case 'carrying':
+                if (this._moveTo(this.targetX, this.targetY)) {
+                    // Dropped at truck
+                    this.hasBox = false;
+                    this.delivered++;
+                    gs.boxesDelivered++;
+                    this.targetX = this.homeX();
+                    this.targetY = this.cy;
+                    this.state   = 'returning';
+                }
+                break;
+
+            case 'returning':
+                if (this._moveTo(this.targetX, this.targetY)) {
+                    this.state = 'idle';
+                    // Will check queue on next tick
+                }
+                break;
+        }
+    }
+
+    // Move toward (tx,ty) at this.speed. Returns true when arrived.
+    _moveTo(tx, ty) {
+        const dx = tx - this.wx;
+        const dy = ty - this.wy;
+        const dist = Math.sqrt(dx*dx + dy*dy);
+        if (dist <= this.speed) {
+            this.wx = tx;
+            this.wy = ty;
+            return true;
+        }
+        this.wx += (dx / dist) * this.speed;
+        this.wy += (dy / dist) * this.speed;
+        return false;
+    }
+
+    get isBusy() {
+        return this.state !== 'idle';
+    }
+}
+
+// ─── INIT LEVEL ───────────────────────────────────────────────────────────────
+function initLevel() {
+    const lv = levels[currentLevelIndex];
+    cancelAnimationFrame(gs.rafId);
+
+    gs.isRunning      = false;
+    gs.boxesDelivered = 0;
+    gs.gameTime       = 0;
+    gs.totalBoxes     = lv.boxCount;
+    gs.storageBoxes   = lv.boxCount;
+    gs.lanes          = [];
+
+    for (let i = 0; i < lv.initialLanes; i++) {
+        gs.lanes.push(makeLane(i, lv.initialLanes, lv.workerSpeed));
+    }
+
+    // UI resets
+    document.getElementById('status').className   = 'status';
+    document.getElementById('status').textContent = '';
+    document.getElementById('feedback').textContent = '';
+    document.getElementById('nextBtn').style.display = 'none';
+    document.getElementById('startBtn').disabled    = false;
+    document.getElementById('startBtn').textContent = '▶️ Start Level';
+
+    updateLaneButtons();
+    updateUI();
+    drawGame();
+}
+
+function makeLane(id, totalLanes, speed) {
+    const laneH = LANE_AREA_HEIGHT / Math.max(totalLanes, 1);
+    const cy    = LANE_TOP_MARGIN + id * laneH + laneH / 2;
+    const lane  = new Lane(id, cy, 6 * speed);
+    lane.wx     = lane.homeX();
+    lane.wy     = cy;
+    return lane;
+}
+
+function recalcLanePositions() {
+    const total = gs.lanes.length;
+    const laneH = LANE_AREA_HEIGHT / Math.max(total, 1);
+    gs.lanes.forEach((ln, i) => {
+        ln.setCY(LANE_TOP_MARGIN + i * laneH + laneH / 2);
+    });
+}
+
+// ─── LANE ADD / REMOVE ────────────────────────────────────────────────────────
+function addLane() {
+    const lv = levels[currentLevelIndex];
+    if (gs.isRunning || gs.lanes.length >= lv.maxLanes) return;
+    const newId = gs.lanes.length;
+    const total = newId + 1;
+    const laneH = LANE_AREA_HEIGHT / total;
+    const cy    = LANE_TOP_MARGIN + newId * laneH + laneH / 2;
+    const lane  = new Lane(newId, cy, 6 * lv.workerSpeed);
+    lane.wx     = lane.homeX();
+    lane.wy     = cy;
+    gs.lanes.push(lane);
+    recalcLanePositions();
+    updateLaneButtons();
+    updateUI();
+    drawGame();
+}
+
+function removeLane() {
+    if (gs.isRunning || gs.lanes.length <= 1) return;
+    const removed = gs.lanes.pop();
+    // Return undelivered boxes to storage
+    gs.storageBoxes += removed.queue.length;
+    if (removed.hasBox) gs.storageBoxes++;
+    recalcLanePositions();
+    updateLaneButtons();
+    updateUI();
+    drawGame();
+}
+
+// ─── BOX MANAGEMENT ──────────────────────────────────────────────────────────
+function addBoxToLane(laneIdx) {
+    if (gs.isRunning || gs.storageBoxes <= 0) return;
+    if (laneIdx >= gs.lanes.length) return;
+    gs.storageBoxes--;
+    gs.lanes[laneIdx].queue.push({});
+    updateUI();
+    drawGame();
+}
+
+function removeBoxFromLane(laneIdx) {
+    if (gs.isRunning) return;
+    if (laneIdx >= gs.lanes.length) return;
+    if (gs.lanes[laneIdx].queue.length === 0) return;
+    gs.lanes[laneIdx].queue.pop();
+    gs.storageBoxes++;
+    updateUI();
+    drawGame();
+}
+
+// ─── GAME LOOP ────────────────────────────────────────────────────────────────
+function startLevel() {
+    if (gs.isRunning) return;
+    gs.isRunning      = true;
+    gs.levelStartTime = performance.now();
+
+    document.getElementById('startBtn').disabled    = true;
+    document.getElementById('addLaneBtn').disabled  = true;
+    document.getElementById('removeLaneBtn').disabled = true;
+    document.getElementById('status').className     = 'status';
+    document.getElementById('status').textContent   = '';
+    document.getElementById('feedback').textContent = '';
+
+    loop();
+}
+
+function loop() {
+    if (!gs.isRunning) return;
+
+    gs.gameTime = (performance.now() - gs.levelStartTime) / 1000;
+
+    const cw = getCanvasW();
+    gs.lanes.forEach(ln => ln.update(cw));
+
+    const allDelivered = gs.boxesDelivered >= gs.totalBoxes;
+    const allIdle      = gs.lanes.every(ln => !ln.isBusy);
+    const noQueue      = gs.lanes.every(ln => ln.queue.length === 0);
+
+    updateUI();
+    drawGame();
+
+    if (allDelivered && allIdle) {
+        endLevel(true);
+        return;
+    }
+    if (gs.gameTime > 15) {
+        endLevel(false);
+        return;
+    }
+
+    gs.rafId = requestAnimationFrame(loop);
+}
+
+// ─── END LEVEL ───────────────────────────────────────────────────────────────
+function endLevel(success) {
+    gs.isRunning = false;
+    cancelAnimationFrame(gs.rafId);
+
+    const lv      = levels[currentLevelIndex];
+    const t       = gs.gameTime;
+    const statusEl  = document.getElementById('status');
+    const feedbackEl = document.getElementById('feedback');
+
+    if (success) {
+        statusEl.className   = 'status success';
+        statusEl.textContent = '✅ Level Complete!';
+
+        const lanesUsed = gs.lanes.length;
+        let timeBonus = t <= 10 ? 50 : t <= 12 ? 40 : 20;
+        let effBonus  = Math.round(30 * (lv.initialLanes / lanesUsed));
+        let total     = 100 + timeBonus + Math.max(0, effBonus);
+
+        let rating = t <= 10
+            ? `<span class="stat-perfect">Perfect Time! 🚀 ${t.toFixed(1)}s</span>`
+            : t <= 12
+            ? `<span class="stat-good">Great Time! ⚡ ${t.toFixed(1)}s</span>`
+            : `<span class="stat-good">Good Time ✓ ${t.toFixed(1)}s</span>`;
+
+        feedbackEl.innerHTML = rating + `
+            <div class="score-display">
+                📊 Efficiency Score: <strong>${total} points</strong><br>
+                ⏱️ Time Bonus: +${timeBonus} pts<br>
+                👷 Efficiency Bonus: +${Math.max(0, effBonus)} pts<br>
+                🎯 Lanes Used: ${lanesUsed} (started with ${lv.initialLanes})
+            </div>`;
+
+        if (currentLevelIndex < levels.length - 1) {
+            document.getElementById('nextBtn').style.display = 'inline-block';
+        } else {
+            feedbackEl.innerHTML += `<br><span style="color:#667eea;font-weight:bold;display:block;margin-top:10px;">🎉 You've completed all levels!</span>`;
+        }
+    } else {
+        statusEl.className   = 'status fail';
+        statusEl.textContent = '❌ Time\'s Up!';
+        feedbackEl.textContent = `${t.toFixed(1)}s — Too slow! Distribute boxes across more lanes.`;
+    }
+
+    document.getElementById('startBtn').disabled   = false;
+    document.getElementById('startBtn').textContent = '▶️ Try Again';
+    updateLaneButtons();
+}
+
+function nextLevel() {
+    if (currentLevelIndex < levels.length - 1) {
+        currentLevelIndex++;
+        initLevel();
+    }
+}
+
+function resetLevel() {
+    cancelAnimationFrame(gs.rafId);
+    gs.isRunning = false;
+    initLevel();
+}
+
+// ─── UI ───────────────────────────────────────────────────────────────────────
+function updateUI() {
+    const lv = levels[currentLevelIndex];
+    document.getElementById('level-num').textContent  = lv.number;
+    document.getElementById('storage-count').textContent = gs.storageBoxes;
+    document.getElementById('delivered').textContent  = gs.boxesDelivered;
+    document.getElementById('lanes-count').textContent = gs.lanes.length;
+
+    // remaining = boxes not yet delivered (in storage + in queues + being carried)
+    let inTransit = 0;
+    gs.lanes.forEach(ln => {
+        inTransit += ln.queue.length + (ln.hasBox ? 1 : 0);
+    });
+    const remaining = gs.totalBoxes - gs.boxesDelivered;
+    document.getElementById('remaining').textContent = Math.max(0, remaining);
+
+    const m = Math.floor(gs.gameTime / 60);
+    const s = (gs.gameTime % 60).toFixed(1);
+    const timerEl = document.getElementById('timer');
+    timerEl.textContent = `${m}:${s.padStart(4, '0')}`;
+    timerEl.className = 'timer' +
+        (gs.gameTime > 12 ? ' danger' : gs.gameTime >= 0.1 && gs.gameTime <= 10 ? ' perfect' : '');
+
+    // Storage visual
+    const storageDiv = document.getElementById('storage-boxes');
+    storageDiv.innerHTML = '';
+    const show = Math.min(gs.storageBoxes, 10);
+    for (let i = 0; i < show; i++) {
+        const b = document.createElement('div');
+        b.className = 'storage-box';
+        storageDiv.appendChild(b);
+    }
+    if (gs.storageBoxes > 10) {
+        const m2 = document.createElement('div');
+        m2.style.cssText = 'font-size:1.2em;font-weight:bold;color:#333;';
+        m2.textContent = `+${gs.storageBoxes - 10}`;
+        storageDiv.appendChild(m2);
+    }
+}
+
+function updateLaneButtons() {
+    const lv = levels[currentLevelIndex];
+    document.getElementById('addLaneBtn').disabled =
+        gs.isRunning || gs.lanes.length >= lv.maxLanes;
+    document.getElementById('removeLaneBtn').disabled =
+        gs.isRunning || gs.lanes.length <= 1;
+    document.getElementById('laneInfo').textContent =
+        `${gs.lanes.length} lane${gs.lanes.length !== 1 ? 's' : ''} active (Max: ${lv.maxLanes})`;
+}
+
+// ─── DRAWING ─────────────────────────────────────────────────────────────────
+function getCanvasW() {
+    return document.getElementById('gameCanvas').clientWidth || 800;
+}
+
+function drawGame() {
+    const canvas = document.getElementById('gameCanvas');
+    const CW = canvas.clientWidth  || 800;
+    const CH = CANVAS_HEIGHT;
+    gs.canvasW = CW;
+
+    const ns = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(ns, 'svg');
+    svg.setAttribute('width',  CW);
+    svg.setAttribute('height', CH);
+    svg.setAttribute('viewBox', `0 0 ${CW} ${CH}`);
+
+    // ── Background ──
+    const bgRect = el(ns, 'rect', { x:0, y:0, width:CW, height:CH, fill:'#d4a574' });
+    svg.appendChild(bgRect);
+
+    // Grid lines
+    for (let gx = 0; gx < CW; gx += 40) {
+        svg.appendChild(el(ns, 'line', { x1:gx, y1:0, x2:gx, y2:CH,
+            stroke:'#c19a6b', 'stroke-width':0.5 }));
+    }
+    for (let gy = 0; gy < CH; gy += 40) {
+        svg.appendChild(el(ns, 'line', { x1:0, y1:gy, x2:CW, y2:gy,
+            stroke:'#c19a6b', 'stroke-width':0.5 }));
+    }
+
+    // ── Per-lane drawing ──
+    gs.lanes.forEach((ln, i) => {
+        const laneH = LANE_AREA_HEIGHT / gs.lanes.length;
+        const top   = ln.cy - laneH / 2 + 4;
+        const h     = laneH - 8;
+
+        // Lane strip
+        svg.appendChild(el(ns, 'rect', {
+            x: 40, y: top,
+            width: CW - 40 - TRUCK_MARGIN - TRUCK_W - 5,
+            height: h,
+            fill:'#e8d7c3', stroke:'#8b7355', 'stroke-width':2, rx:4
+        }));
+
+        // Lane label (top-left of strip)
+        const lbl = el(ns, 'text', {
+            x:48, y: top + 14,
+            fill:'#555', 'font-size':11, 'font-weight':'bold'
+        });
+        lbl.textContent = `Lane ${ln.id + 1}`;
+        svg.appendChild(lbl);
+
+        // ── Truck ──
+        const tx = CW - TRUCK_MARGIN - TRUCK_W;
+        const ty = ln.cy - TRUCK_H / 2;
+        // Cargo body
+        svg.appendChild(el(ns, 'rect', {
+            x:tx, y:ty, width:TRUCK_W - 18, height:TRUCK_H,
+            fill:'#ff6b6b', stroke:'#cc0000', 'stroke-width':2, rx:2
+        }));
+        // Cab
+        svg.appendChild(el(ns, 'rect', {
+            x: tx + TRUCK_W - 20, y: ty + 4,
+            width:16, height: TRUCK_H - 8,
+            fill:'#cc4444', stroke:'#aa0000', 'stroke-width':1, rx:2
+        }));
+        // Windshield
+        svg.appendChild(el(ns, 'rect', {
+            x: tx + TRUCK_W - 18, y: ty + 7,
+            width:10, height:10,
+            fill:'#aaddff', rx:1
+        }));
+        // Wheels
+        [-4, TRUCK_H - 8].forEach(wy => {
+            svg.appendChild(el(ns, 'circle', {
+                cx: tx + 10, cy: ty + TRUCK_H + wy/2 + 2, r:5,
+                fill:'#333'
+            }));
+            svg.appendChild(el(ns, 'circle', {
+                cx: tx + TRUCK_W - 24, cy: ty + TRUCK_H + wy/2 + 2, r:5,
+                fill:'#333'
+            }));
+        });
+        // Truck number
+        const tn = el(ns, 'text', {
+            x: tx + (TRUCK_W - 18) / 2, y: ln.cy + 5,
+            'text-anchor':'middle', fill:'white', 'font-size':12, 'font-weight':'bold'
+        });
+        tn.textContent = `T${i+1}`;
+        svg.appendChild(tn);
+
+        // ── Queued boxes (stacked left of pickup point) ──
+        const queueStartX = ln.homeX() + 45;
+        const maxShow = Math.min(ln.queue.length, 5);
+        for (let q = 0; q < maxShow; q++) {
+            svg.appendChild(el(ns, 'rect', {
+                x: queueStartX + q * (BOX_W + 4),
+                y: ln.cy - BOX_H / 2,
+                width: BOX_W, height: BOX_H,
+                fill:'#ff9800', stroke:'#e65c00', 'stroke-width':1.5, rx:2
+            }));
+        }
+        if (ln.queue.length > 5) {
+            const qMore = el(ns, 'text', {
+                x: queueStartX + 5 * (BOX_W + 4) + 4,
+                y: ln.cy + 5,
+                fill:'#e65c00', 'font-size':11, 'font-weight':'bold'
+            });
+            qMore.textContent = `+${ln.queue.length - 5}`;
+            svg.appendChild(qMore);
+        }
+
+        // Queue count badge
+        if (ln.queue.length > 0) {
+            const badge = el(ns, 'text', {
+                x: queueStartX - 4,
+                y: ln.cy - BOX_H / 2 - 4,
+                fill:'#333', 'font-size':10, 'font-weight':'bold'
+            });
+            badge.textContent = `${ln.queue.length} box${ln.queue.length !== 1 ? 'es' : ''}`;
+            svg.appendChild(badge);
+        }
+
+        // ── Worker ──
+        const workerColor = ln.state === 'idle' ? '#aaa'
+            : ln.state === 'carrying' ? '#51cf66'
+            : '#667eea';
+
+        // Shadow
+        svg.appendChild(el(ns, 'ellipse', {
+            cx: ln.wx, cy: ln.wy + WORKER_R + 2,
+            rx: WORKER_R, ry: 4,
+            fill:'rgba(0,0,0,0.15)'
+        }));
+        // Body
+        svg.appendChild(el(ns, 'circle', {
+            cx: ln.wx, cy: ln.wy,
+            r: WORKER_R,
+            fill: workerColor, stroke:'#fff', 'stroke-width':2
+        }));
+        // Hardhat
+        svg.appendChild(el(ns, 'rect', {
+            x: ln.wx - 9, y: ln.wy - WORKER_R - 4,
+            width:18, height:7,
+            fill:'#ffc107', rx:3
+        }));
+
+        // Carried box (above worker)
+        if (ln.hasBox) {
+            svg.appendChild(el(ns, 'rect', {
+                x: ln.wx - BOX_W / 2,
+                y: ln.wy - WORKER_R - BOX_H - 2,
+                width: BOX_W, height: BOX_H,
+                fill:'#ff9800', stroke:'#e65c00', 'stroke-width':1.5, rx:2
+            }));
+        }
+
+        // ── In-lane + / − buttons (only when not running) ──
+        if (!gs.isRunning) {
+            // + button
+            const plusX = 50;
+            const plusY = ln.cy;
+            const plusBg = el(ns, 'rect', {
+                x: plusX - 10, y: plusY - 10,
+                width:20, height:20,
+                fill: gs.storageBoxes > 0 ? '#51cf66' : '#ccc',
+                rx:4, stroke:'#fff', 'stroke-width':1,
+                style: gs.storageBoxes > 0 ? 'cursor:pointer' : 'cursor:not-allowed'
+            });
+            plusBg.addEventListener('click', () => addBoxToLane(i));
+            svg.appendChild(plusBg);
+
+            const plusTxt = el(ns, 'text', {
+                x: plusX, y: plusY + 5,
+                'text-anchor':'middle', fill:'white',
+                'font-size':16, 'font-weight':'bold',
+                'pointer-events':'none'
+            });
+            plusTxt.textContent = '+';
+            svg.appendChild(plusTxt);
+
+            // − button (only if boxes in queue)
+            if (ln.queue.length > 0) {
+                const minX = plusX + 24;
+                const minBg = el(ns, 'rect', {
+                    x: minX - 10, y: plusY - 10,
+                    width:20, height:20,
+                    fill:'#ff6b6b',
+                    rx:4, stroke:'#fff', 'stroke-width':1,
+                    style:'cursor:pointer'
+                });
+                minBg.addEventListener('click', () => removeBoxFromLane(i));
+                svg.appendChild(minBg);
+
+                const minTxt = el(ns, 'text', {
+                    x: minX, y: plusY + 5,
+                    'text-anchor':'middle', fill:'white',
+                    'font-size':18, 'font-weight':'bold',
+                    'pointer-events':'none'
+                });
+                minTxt.textContent = '−';
+                svg.appendChild(minTxt);
+            }
+        }
+    });
+
+    // ── Progress bar ──
+    const progressW = CW - 40;
+    const progressH = 12;
+    const progressY = CH - 25;
+    const progressX = 20;
+    svg.appendChild(el(ns, 'rect', {
+        x:progressX, y:progressY,
+        width:progressW, height:progressH,
+        fill:'#e0e0e0', rx:6
+    }));
+    const pct = gs.totalBoxes > 0 ? gs.boxesDelivered / gs.totalBoxes : 0;
+    if (pct > 0) {
+        svg.appendChild(el(ns, 'rect', {
+            x:progressX, y:progressY,
+            width: progressW * pct, height:progressH,
+            fill:'#51cf66', rx:6
+        }));
+    }
+    const progLabel = el(ns, 'text', {
+        x: CW / 2, y: progressY + 9,
+        'text-anchor':'middle', fill:'#333', 'font-size':9, 'font-weight':'bold'
+    });
+    progLabel.textContent = `${gs.boxesDelivered} / ${gs.totalBoxes} delivered`;
+    svg.appendChild(progLabel);
+
+    canvas.innerHTML = '';
+    canvas.appendChild(svg);
+}
+
+// Helper: create SVG element with attributes
+function el(ns, tag, attrs) {
+    const e = document.createElementNS(ns, tag);
+    for (const [k, v] of Object.entries(attrs)) {
+        e.setAttribute(k, v);
+    }
+    return e;
+}
+
+// ─── BOOT ─────────────────────────────────────────────────────────────────────
+window.addEventListener('load', () => initLevel());
+window.addEventListener('resize', () => { if (!gs.isRunning) drawGame(); });
+</script>
+
+<!-- ═══════════════════════════════════════════════════════════════════════════
+     LESSON SECTION
+     ═══════════════════════════════════════════════════════════════════════════ -->
+<style>
+    .lesson-container {
+        background: white;
+        padding: 40px 20px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        margin-top: 20px;
+    }
+
+    .lesson-wrapper {
+        background: white;
+        border-radius: 20px;
+        box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+        max-width: 1200px;
+        width: 100%;
+        padding: 40px;
+    }
+
+    .lesson-title { text-align:center; color:#333; font-size:2.2em; margin-bottom:10px; font-weight:bold; }
+    .lesson-subtitle { text-align:center; color:#666; font-size:1.1em; margin-bottom:40px; }
+
+    .lesson-section { margin-bottom:40px; display:flex; gap:30px; align-items:center; flex-wrap:wrap; }
+    .lesson-text { flex:1; min-width:300px; }
+    .lesson-text h3 { color:#667eea; font-size:1.5em; margin-bottom:15px; }
+    .lesson-text p { color:#555; font-size:1em; line-height:1.8; margin-bottom:12px; }
+    .lesson-visual { flex:1; min-width:300px; display:flex; justify-content:center; }
+
+    .comparison-box {
+        background:#f5f7ff; border-left:4px solid #667eea;
+        padding:20px; border-radius:8px; margin:15px 0;
+    }
+    .comparison-item { display:flex; gap:15px; margin:12px 0; align-items:center; }
+    .comparison-label { font-weight:bold; color:#333; min-width:100px; }
+    .comparison-value { color:#667eea; font-weight:bold; font-size:1.1em; }
+
+    .speedup-visualizer { display:flex; gap:30px; margin:30px 0; align-items:flex-end; }
+    .bar-group { flex:1; text-align:center; }
+    .bar-group h4 { margin-bottom:10px; color:#333; }
+    .bar-group .label { font-size:0.9em; color:#666; margin-bottom:5px; }
+    .speed-bar { width:100%; border-radius:5px; margin-bottom:8px; display:flex; align-items:center; justify-content:center; color:white; font-weight:bold; }
+    .bar-sequential { background:linear-gradient(90deg,#ff6b6b,#ff5252); height:40px; }
+    .bar-parallel { background:linear-gradient(90deg,#51cf66,#40c057); height:90px; }
+
+    .key-points { background:#f0f7ff; border-left:4px solid #667eea; padding:20px; border-radius:8px; margin:20px 0; }
+    .key-points h4 { color:#667eea; margin-bottom:12px; }
+    .key-points ul { list-style:none; padding:0; }
+    .key-points li { padding:8px 0; color:#555; border-bottom:1px solid #e0e7ff; }
+    .key-points li:before { content:"✓ "; color:#667eea; font-weight:bold; margin-right:8px; }
+    .key-points li:last-child { border-bottom:none; }
+
+    .divider { height:2px; background:linear-gradient(90deg,transparent 0%,#667eea 50%,transparent 100%); margin:40px 0; }
+
+    @media (max-width:768px) {
+        .lesson-wrapper { padding:25px; }
+        .lesson-title { font-size:1.8em; }
+        .lesson-section { gap:20px; }
+        .speedup-visualizer { flex-direction:column; gap:20px; }
+    }
+</style>
+
+<div class="lesson-container">
+    <div class="lesson-wrapper">
+        <h1 class="lesson-title">📚 Understanding Parallel Computing</h1>
+        <p class="lesson-subtitle">How workers run faster together</p>
+
+        <div class="lesson-section">
+            <div class="lesson-text">
+                <h3>🤔 What's Parallel Computing?</h3>
+                <p>Parallel computing means breaking a big task into smaller pieces and working on them <strong>at the same time</strong> instead of one after another.</p>
+                <p>In the warehouse game:</p>
+                <div class="comparison-box">
+                    <div class="comparison-item"><span class="comparison-label">Sequential:</span><span>1 worker delivers ALL boxes alone</span></div>
+                    <div class="comparison-item"><span class="comparison-label">Parallel:</span><span>Many workers deliver boxes together</span></div>
+                </div>
+                <p><strong>Result:</strong> Parallel is MUCH faster! ⚡</p>
+            </div>
+            <div class="lesson-visual">
+                <svg width="300" height="200" viewBox="0 0 300 200" style="background:#f5f7ff;border-radius:10px;">
+                    <text x="75" y="25" font-weight="bold" font-size="14" text-anchor="middle">Sequential</text>
+                    <circle cx="75" cy="60" r="15" fill="#667eea"/>
+                    <line x1="75" y1="75" x2="75" y2="110" stroke="#ddd" stroke-width="2" stroke-dasharray="5,5"/>
+                    <rect x="55" y="115" width="40" height="30" fill="#ff9800" stroke="#ff8c00" stroke-width="2"/>
+                    <text x="75" y="175" font-size="12" text-anchor="middle" fill="#666">Takes longer</text>
+                    <text x="225" y="25" font-weight="bold" font-size="14" text-anchor="middle">Parallel</text>
+                    <circle cx="205" cy="60" r="12" fill="#51cf66"/>
+                    <circle cx="225" cy="60" r="12" fill="#51cf66"/>
+                    <circle cx="245" cy="60" r="12" fill="#51cf66"/>
+                    <line x1="205" y1="75" x2="205" y2="110" stroke="#ddd" stroke-width="2" stroke-dasharray="5,5"/>
+                    <line x1="225" y1="75" x2="225" y2="110" stroke="#ddd" stroke-width="2" stroke-dasharray="5,5"/>
+                    <line x1="245" y1="75" x2="245" y2="110" stroke="#ddd" stroke-width="2" stroke-dasharray="5,5"/>
+                    <rect x="185" y="115" width="40" height="30" fill="#ff9800" stroke="#ff8c00" stroke-width="2"/>
+                    <text x="225" y="175" font-size="12" text-anchor="middle" fill="#51cf66" font-weight="bold">Much faster! ⚡</text>
+                </svg>
+            </div>
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="lesson-section">
+            <div class="lesson-text">
+                <h3>⚡ The Speedup Effect</h3>
+                <p>When you add more workers (processors), tasks complete faster. This is called <strong>speedup</strong>.</p>
+                <div class="key-points">
+                    <h4>Key Insight</h4>
+                    <ul>
+                        <li>1 worker = baseline time</li>
+                        <li>2 workers = roughly 2x faster</li>
+                        <li>4 workers = roughly 4x faster</li>
+                    </ul>
+                </div>
+                <p><strong>But there's a limit!</strong> At some point, adding more workers won't help (coordination overhead).</p>
+            </div>
+            <div class="lesson-visual">
+                <div class="speedup-visualizer">
+                    <div class="bar-group">
+                        <h4>Sequential</h4>
+                        <div class="label">1 worker</div>
+                        <div class="speed-bar bar-sequential">100%</div>
+                    </div>
+                    <div class="bar-group">
+                        <h4>Parallel</h4>
+                        <div class="label">4 workers</div>
+                        <div class="speed-bar bar-parallel">4x faster</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="lesson-section">
+            <div class="lesson-text">
+                <h3>🌍 Real-World Parallel Computing</h3>
+                <p>Parallel computing is everywhere in modern technology:</p>
+                <div class="comparison-box"><strong>GPU Graphics:</strong> Thousands of tiny processors work on pixels simultaneously</div>
+                <div class="comparison-box"><strong>Web Servers:</strong> Handle thousands of user requests in parallel</div>
+                <div class="comparison-box"><strong>Video Processing:</strong> Process frames in parallel for faster rendering</div>
+                <div class="comparison-box"><strong>Data Analysis:</strong> Analyze huge datasets faster by splitting work across cores</div>
+            </div>
+            <div class="lesson-visual">
+                <svg width="300" height="280" viewBox="0 0 300 280" style="background:#f5f7ff;border-radius:10px;">
+                    <text x="150" y="25" font-weight="bold" font-size="14" text-anchor="middle">Modern CPU: 8 Cores</text>
+                    <rect x="30"  y="50"  width="50" height="50" fill="#667eea" stroke="#5568d3" stroke-width="2"/><text x="55"  y="82" text-anchor="middle" fill="white" font-weight="bold">C1</text>
+                    <rect x="90"  y="50"  width="50" height="50" fill="#667eea" stroke="#5568d3" stroke-width="2"/><text x="115" y="82" text-anchor="middle" fill="white" font-weight="bold">C2</text>
+                    <rect x="150" y="50"  width="50" height="50" fill="#667eea" stroke="#5568d3" stroke-width="2"/><text x="175" y="82" text-anchor="middle" fill="white" font-weight="bold">C3</text>
+                    <rect x="210" y="50"  width="50" height="50" fill="#667eea" stroke="#5568d3" stroke-width="2"/><text x="235" y="82" text-anchor="middle" fill="white" font-weight="bold">C4</text>
+                    <rect x="30"  y="110" width="50" height="50" fill="#51cf66" stroke="#40c057" stroke-width="2"/><text x="55"  y="142" text-anchor="middle" fill="white" font-weight="bold">C5</text>
+                    <rect x="90"  y="110" width="50" height="50" fill="#51cf66" stroke="#40c057" stroke-width="2"/><text x="115" y="142" text-anchor="middle" fill="white" font-weight="bold">C6</text>
+                    <rect x="150" y="110" width="50" height="50" fill="#51cf66" stroke="#40c057" stroke-width="2"/><text x="175" y="142" text-anchor="middle" fill="white" font-weight="bold">C7</text>
+                    <rect x="210" y="110" width="50" height="50" fill="#51cf66" stroke="#40c057" stroke-width="2"/><text x="235" y="142" text-anchor="middle" fill="white" font-weight="bold">C8</text>
+                    <text x="150" y="190" text-anchor="middle" font-size="12" fill="#666">All running tasks</text>
+                    <text x="150" y="210" text-anchor="middle" font-size="12" fill="#666">at the SAME TIME</text>
+                    <text x="150" y="250" text-anchor="middle" font-size="14" font-weight="bold" fill="#51cf66">🚀 That's parallel!</text>
+                </svg>
+            </div>
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="key-points">
+            <h4>💡 Key Takeaways</h4>
+            <ul>
+                <li>Parallel computing breaks big tasks into smaller ones</li>
+                <li>Multiple processors work on different tasks simultaneously</li>
+                <li>This creates significant speedup in execution time</li>
+                <li>Real-world examples: GPUs, servers, video games, data processing</li>
+                <li>Not all problems can be easily parallelized (some tasks depend on each other)</li>
+            </ul>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
# Parallel Computing Lesson - Changes Summary

## What Changed

Refactored the parallel computing lesson to follow Jekyll best practices:

1. **Moved layout to `_layouts/`** - Changed from `assets/html/projects/parallelAndComputinglesson/` to `_layouts/parallelAndComputinglesson.html` to align with Jekyll conventions
2. **Converted to fragment** - Removed DOCTYPE, html, head, and body tags. Jekyll wraps the content automatically.
3. **Unique naming** - Renamed `parallel.html` → `parallelAndComputinglesson.html` to prevent future naming conflicts
4. **Updated Makefile For Project** - Build process now copies the layout directly to `_layouts/` instead of nested asset directories
5. **Direct layout usage** - `lesson.md` now uses `layout: parallelAndComputinglesson` instead of linking to a separate HTML file
