### PR TITLE
Updating jekyll-gh-pages.yml for Node24 pre-support

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -21,6 +21,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Build job
   build:


### PR DESCRIPTION
Adding env variables to the Jekyll config to force it to use Node24, also switching from actions/checkout@v3 to @v4 to support the latest versions of Node24. These changes will fix the deprecation warnings, but 2 other errors will take their place until June 2nd, which by then hopefully the authors for actions/checkout, actions/deploy-pages will have added native Node24 support instead of Node20.