### PR TITLE
Reorder PNEC capstone feature cards by resident journey

### DIFF
--- a/_includes/pnec-capstone.html
+++ b/_includes/pnec-capstone.html
@@ -68,6 +68,36 @@
 
     <article class="pnec-cap-feature">
       <div class="pnec-cap-feature-body">
+        <span class="pnec-cap-tag">Connects every household</span>
+        <h3>Find Your Neighborhood</h3>
+        <p>An interactive map links each Poway household to its block coordinator,
+           nearest fire station, evacuation guidance, and emergency contacts. This
+           is how the corps reaches people fast when minutes matter.</p>
+        <a class="pnec-cap-link" href="https://pnec.opencodingsociety.com/pages/find-your-neighborhood.html" target="_blank" rel="noopener">Find a neighborhood →</a>
+      </div>
+      <figure class="pnec-cap-figure" data-shot="Interactive Poway neighborhood map">
+        <img src="{{ site.baseurl }}/images/capstone/pnec/map.png" alt="Interactive Poway neighborhood map with a neighborhood detail panel"
+             loading="lazy" onerror="this.closest('.pnec-cap-figure').classList.add('is-empty')">
+      </figure>
+    </article>
+
+    <article class="pnec-cap-feature pnec-cap-feature--rev">
+      <div class="pnec-cap-feature-body">
+        <span class="pnec-cap-tag">Answers, any time</span>
+        <h3>Helper Bot</h3>
+        <p>A friendly assistant answers preparedness questions instantly, like what
+           belongs in a 72 hour kit or how to find an evacuation route, using
+           PNEC's real programs and resources so the guidance is always on message.</p>
+        <a class="pnec-cap-link" href="https://pnec.opencodingsociety.com/#chatbot-trigger-btn" target="_blank" rel="noopener">Ask it a question →</a>
+      </div>
+      <figure class="pnec-cap-figure" data-shot="Helper Bot answering a preparedness question">
+        <img src="{{ site.baseurl }}/images/capstone/pnec/chatbot.png" alt="Helper Bot answering a Poway preparedness question"
+             loading="lazy" onerror="this.closest('.pnec-cap-figure').classList.add('is-empty')">
+      </figure>
+    </article>
+
+    <article class="pnec-cap-feature">
+      <div class="pnec-cap-feature-body">
         <span class="pnec-cap-tag">Live, on the homepage</span>
         <h3>Risk Watch</h3>
         <p>The moment a resident lands on the site they see today's
@@ -84,51 +114,6 @@
 
     <article class="pnec-cap-feature pnec-cap-feature--rev">
       <div class="pnec-cap-feature-body">
-        <span class="pnec-cap-tag">Run by volunteers, no developer</span>
-        <h3>Edit and publish in minutes</h3>
-        <p>An approved volunteer can update any page from the browser and publish in
-           minutes. Built-in AI turns a plain request into the change, so PNEC is
-           never waiting on a coder to post an alert or fix a date before an event.</p>
-        <a class="pnec-cap-link" href="https://pnec.opencodingsociety.com/pages/admin-editor.html" target="_blank" rel="noopener">See the editor →</a>
-      </div>
-      <figure class="pnec-cap-figure" data-shot="The live theme editor volunteers use">
-        <img src="{{ site.baseurl }}/images/capstone/pnec/theme-editor.png" alt="The live theme editor volunteers use to update the site"
-             loading="lazy" onerror="this.closest('.pnec-cap-figure').classList.add('is-empty')">
-      </figure>
-    </article>
-
-    <article class="pnec-cap-feature">
-      <div class="pnec-cap-feature-body">
-        <span class="pnec-cap-tag">Answers, any time</span>
-        <h3>Helper Bot</h3>
-        <p>A friendly assistant answers preparedness questions instantly, like what
-           belongs in a 72 hour kit or how to find an evacuation route, using
-           PNEC's real programs and resources so the guidance is always on message.</p>
-        <a class="pnec-cap-link" href="https://pnec.opencodingsociety.com/#chatbot-trigger-btn" target="_blank" rel="noopener">Ask it a question →</a>
-      </div>
-      <figure class="pnec-cap-figure" data-shot="Helper Bot answering a preparedness question">
-        <img src="{{ site.baseurl }}/images/capstone/pnec/chatbot.png" alt="Helper Bot answering a Poway preparedness question"
-             loading="lazy" onerror="this.closest('.pnec-cap-figure').classList.add('is-empty')">
-      </figure>
-    </article>
-
-    <article class="pnec-cap-feature pnec-cap-feature--rev">
-      <div class="pnec-cap-feature-body">
-        <span class="pnec-cap-tag">Connects every household</span>
-        <h3>Find Your Neighborhood</h3>
-        <p>An interactive map links each Poway household to its block coordinator,
-           nearest fire station, evacuation guidance, and emergency contacts. This
-           is how the corps reaches people fast when minutes matter.</p>
-        <a class="pnec-cap-link" href="https://pnec.opencodingsociety.com/pages/find-your-neighborhood.html" target="_blank" rel="noopener">Find a neighborhood →</a>
-      </div>
-      <figure class="pnec-cap-figure" data-shot="Interactive Poway neighborhood map">
-        <img src="{{ site.baseurl }}/images/capstone/pnec/map.png" alt="Interactive Poway neighborhood map with a neighborhood detail panel"
-             loading="lazy" onerror="this.closest('.pnec-cap-figure').classList.add('is-empty')">
-      </figure>
-    </article>
-
-    <article class="pnec-cap-feature">
-      <div class="pnec-cap-feature-body">
         <span class="pnec-cap-tag">Built to grow</span>
         <h3>Member accounts and roles</h3>
         <p>Secure accounts for <strong>residents</strong>, <strong>volunteers</strong>,
@@ -138,6 +123,21 @@
       </div>
       <figure class="pnec-cap-figure" data-shot="Secure member sign-in">
         <img src="{{ site.baseurl }}/images/capstone/pnec/dashboard.png" alt="Secure member sign-in for residents, volunteers and admins"
+             loading="lazy" onerror="this.closest('.pnec-cap-figure').classList.add('is-empty')">
+      </figure>
+    </article>
+
+    <article class="pnec-cap-feature">
+      <div class="pnec-cap-feature-body">
+        <span class="pnec-cap-tag">Run by volunteers, no developer</span>
+        <h3>Edit and publish in minutes</h3>
+        <p>An approved volunteer can update any page from the browser and publish in
+           minutes. Built-in AI turns a plain request into the change, so PNEC is
+           never waiting on a coder to post an alert or fix a date before an event.</p>
+        <a class="pnec-cap-link" href="https://pnec.opencodingsociety.com/pages/admin-editor.html" target="_blank" rel="noopener">See the editor →</a>
+      </div>
+      <figure class="pnec-cap-figure" data-shot="The live theme editor volunteers use">
+        <img src="{{ site.baseurl }}/images/capstone/pnec/theme-editor.png" alt="The live theme editor volunteers use to update the site"
              loading="lazy" onerror="this.closest('.pnec-cap-figure').classList.add('is-empty')">
       </figure>
     </article>


### PR DESCRIPTION
Reordered the five feature cards in the "What Poway gets now" section on the PNEC capstone page.

New order:

1. Find Your Neighborhood 
2. Helper Bot 
3. Risk Watch
4. Member accounts and roles 
5. Edit and publish in minutes

