### PR TITLE
Fix url for frontend in capstone

### DIFF
--- a/_includes/doing-exceptional-deeds.html
+++ b/_includes/doing-exceptional-deeds.html
@@ -385,7 +385,7 @@
   <div class="ded-links-section" style="margin-bottom:1.75rem;">
     <p><strong>Live Project</strong><br>Frontend + backend deployed and accessible now</p>
     <div class="ded-links-row">
-      <a href="https://deeds.opencodingsociety.com/dad" class="ded-link-btn" target="_blank" rel="noopener noreferrer">Open the Site ↗</a>
+      <a href="https://deeds.opencodingsociety.com" class="ded-link-btn" target="_blank" rel="noopener noreferrer">Open the Site ↗</a>
       <a href="https://dad.opencodingsociety.com/" class="ded-link-btn ded-link-outline" target="_blank" rel="noopener noreferrer">Backend API ↗</a>
     </div>
   </div>


### PR DESCRIPTION
Just changed the frontend link on capstone to the new url