### PR TITLE
Add contributors for Level 4 in README.md

### DIFF
--- a/_projects/games/mansionGame/docs/README.md
+++ b/_projects/games/mansionGame/docs/README.md
@@ -23,7 +23,8 @@ Dhruv, Siddharth, Pranav, Lance, Yiming, Arjun:
 <https://github.com/users/dhruvA207/projects/2>
 
 ### Level 4
-
+Seonyoo, Rigved, Rishab, Jasan, Krish, Vihaan, Aarnav
+<https://github.com/users/Jas-Bop/projects/1/views/3>
 
 ### Level 5
 Pranay, Ishan, Aadi, Aryan, Chet, Kash:  


### PR DESCRIPTION
<img width="1332" height="211" alt="image" src="https://github.com/user-attachments/assets/e3d7c6b3-90a1-4111-be72-9b3ba3a00ae1" />

There appears to be a bug: I didn't change this, but it says I did. The links are identical so it shouldn't matter