### PR TITLE
Fix gist export on the live site, split into reusable files, add docs

### DIFF
--- a/_includes/gist-export-button.html
+++ b/_includes/gist-export-button.html
@@ -37,4 +37,4 @@
 
 </div>
 
-<script src="{{ '/assets/js/gist-export-button.js' | relative_url }}" defer></script>
+<script type="module" src="{{ '/assets/js/gist-export-button.js' | relative_url }}"></script>

--- a/_includes/themes/minima/base.html
+++ b/_includes/themes/minima/base.html
@@ -21,14 +21,6 @@
           {% include admin_foundation.html %}
         {% endif %}
 
-        {% if page.grading_modules %}
-          <div class="grading-actions-wrapper">
-            {% include microblog_foundation.html %}
-            {% include grading_modules.html %}
-          </div>
-        {% endif %}
-
-
         <main class="page-content{% if page.url contains '/capstone/' or page.permalink contains '/capstone/' or page.categories contains 'Capstone' %} capstone-page{% endif %}" aria-label="Content">
             <div class="wrapper">
                                 <div class="opencs_root">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -79,6 +79,11 @@ Check if this is a course lesson and determine which course context to use
           {% include gist-export-button.html %}
           {% endif %}
 
+          {% if page.grading_modules %}
+          {% comment %} Render the grading/submission module at the bottom of the lesson content (not above it) {% endcomment %}
+          {% include grading_modules.html %}
+          {% endif %}
+
           {% if page.assignment %}
           {% include lesson-submission-form.html %}
           <p style="margin-top: 12px; color: #9ca3af; font-size: 0.95rem;">
@@ -1314,6 +1319,11 @@ Check if this is a course lesson and determine which course context to use
     {%- endif -%}
 
     {{ content }}
+
+    {% if page.grading_modules %}
+    {% comment %} Grading/submission module at the bottom of the content (non-course-lesson pages) {% endcomment %}
+    {% include grading_modules.html %}
+    {% endif %}
 
     {% if page.assignment %}
     <div class="assignment-submission">

--- a/_posts/Foundation/C-github_pages/2026-08-17-gist-module.md
+++ b/_posts/Foundation/C-github_pages/2026-08-17-gist-module.md
@@ -1,0 +1,415 @@
+---
+layout: post
+title: Gist Module
+description: A shared service for moving a bundle of files out of a page and getting them back again. Any feature that needs to hand work to another person, another page, another machine, or another system builds on it instead of inventing its own storage.
+permalink: /gist
+toc: true
+breadcrumb: True
+---
+
+## What it is
+
+The Gist Module is a way to take a set of files from a page, put them somewhere
+durable, and get back a URL that points at them. Give that URL back later and the
+files come out again.
+
+```
+export  →  files in,  URL out
+import  →  URL in,    files out
+```
+
+That is the entire service. It has no opinion about what the files contain — code,
+notes, answers, configuration — and no opinion about who asks for them. Features
+supply the meaning; the module supplies the transport.
+
+## Why it exists
+
+### A page cannot keep a secret
+
+The OCS site is static. It is built ahead of time and served as plain files, so
+everything it ships is readable by anyone who opens View Source. There is nowhere
+in a page to hide a credential.
+
+Storing files on a student's behalf requires one. So the browser does not get the
+credential — it asks the Spring backend to act for it. The backend runs on a
+machine OCS controls, holds the token, and returns only the result.
+
+```
+browser ──files──────> Spring ──files + token──> GitHub
+browser <────URL────── Spring <────────────────
+```
+
+### A URL is the point
+
+Most page state has nowhere to go:
+
+| Where state lives | How long it survives | Who else can reach it |
+|---|---|---|
+| A variable | until the tab refreshes | nobody |
+| `localStorage` | until the browser is cleared | nobody — one machine only |
+| A database row | indefinitely | our app, with a login and a schema |
+| **A gist** | indefinitely | anyone given the link, including tools outside OCS |
+
+A variable cannot be sent to somebody. Once a bundle has a URL it can be pasted
+into a message, handed to a teacher, opened by another page, fetched by a script,
+or kept by a student after they leave.
+
+That is the property the module exists to provide: **state with an address.**
+
+### When not to use it
+
+It is not a database and not a system of record.
+
+- **You cannot search it.** "Every student who scored below 70" is a database
+  question; a gist cannot answer it.
+- **It is not private.** Bundles are unlisted, not protected — anyone with the
+  link can read one.
+- **It depends on GitHub** being reachable and the server's token being valid.
+
+The usual arrangement is both: the record goes in the database, and the record
+stores the URL of the bundle that holds the content.
+
+---
+
+## Quick start
+
+The smallest thing that works:
+
+```js
+import { exportToGist, importFromGist } from '/assets/js/gist.js';
+
+// send
+const url = await exportToGist(
+  { 'notes.txt': { content: 'hello world' } },
+  { type: 'demo' }
+);
+
+// get it back
+const { files } = await importFromGist(url);
+console.log(files['notes.txt'].content);   // "hello world"
+```
+
+Any script using these must be loaded as a module:
+
+{% raw %}
+```html
+<script type="module" src="{{ '/assets/js/my-feature.js' | relative_url }}"></script>
+```
+{% endraw %}
+
+An `import` inside a plain `<script>` is a syntax error, and the file will fail
+silently.
+
+---
+
+## The HTTP API
+
+Two endpoints, both public, both requiring `GIST_TOKEN` on the server.
+
+### Create a bundle
+
+```http
+POST /api/grades/create-gist
+Content-Type: application/json
+X-Origin: client
+```
+
+```json
+{
+  "files": {
+    "notes.txt": { "content": "hello world" },
+    "main.java": { "content": "public class Main { }" }
+  },
+  "description": "optional label"
+}
+```
+
+Returns:
+
+```json
+{ "success": true, "url": "https://gist.github.com/user/3f7a1b..." }
+```
+
+Bundles are created unlisted. The server sets this itself, so a caller cannot ask
+for a listed one.
+
+### Read a bundle
+
+```http
+GET /api/grades/read-gist/{id}
+```
+
+`{id}` must be hexadecimal, 6–64 characters. Anything else is rejected before the
+server contacts GitHub.
+
+Returns:
+
+```json
+{
+  "success": true,
+  "files": { "notes.txt": { "content": "hello world" } },
+  "description": "optional label"
+}
+```
+
+Only file contents come back. GitHub's own response also carries `raw_url`,
+`size`, `truncated`, `owner` and more; none of it is passed through.
+
+### Errors
+
+| Status | Body | Meaning |
+|---|---|---|
+| `400` | `{"error":"Invalid gist id"}` | malformed id — checked before anything else |
+| `400` | `{"error":"No files provided"}` | empty bundle |
+| `404` | `{"error":"No gist with that id"}` | nothing at that id |
+| `500` | `{"error":"Gist token not configured on server"}` | `GIST_TOKEN` unset |
+| `502` | `{"error":"Empty response from GitHub"}` | GitHub replied with nothing |
+
+Calls to GitHub time out after 10 seconds, so a stalled request cannot hold a
+server thread open indefinitely.
+
+---
+
+## Browser modules
+
+Two files, kept deliberately separate:
+
+> **`gist.js` never imports a producer. `runner-io.js` never imports a transport.
+> Only a feature imports both.**
+
+This is what makes them reusable. Because the runner reader knows nothing about
+gists, the same reader can send code to an AI grader or a chat message with no
+gist involved. Because the transport knows nothing about runners, it can carry a
+bundle that never came from one.
+
+### `gist.js`
+
+```js
+import {
+  exportToGist, importFromGist, gistIdFrom, readManifest, MANIFEST
+} from '/assets/js/gist.js';
+```
+
+#### `exportToGist(files, opts?) → Promise<string>`
+
+Sends a bundle; resolves to its URL.
+
+| Parameter | Meaning |
+|---|---|
+| `files` | `{ "name.ext": { content: "..." } }` |
+| `opts.type` | what this bundle is, e.g. `'portfolio'` — recorded in the manifest |
+| `opts.description` | human-readable label |
+
+Throws if the bundle is empty. On `401`/`403` throws `Sign in before exporting.`
+
+#### `importFromGist(urlOrId) → Promise<{ files, description, manifest }>`
+
+Opens a bundle. Accepts a full URL or a bare id, and rejects malformed input
+*before* making any request.
+
+#### `gistIdFrom(urlOrId) → string | null`
+
+Extracts an id from whatever someone pastes; `null` if there isn't one.
+
+```js
+gistIdFrom('https://gist.github.com/kush1434/3f7a1b...');   // '3f7a1b...'
+gistIdFrom('https://gist.github.com/3f7a1b...');            // '3f7a1b...'
+gistIdFrom('3f7a1b...');                                     // '3f7a1b...'
+gistIdFrom('.../3f7a1b...#file-main-java');                  // '3f7a1b...'
+gistIdFrom('https://example.com/nope');                      // null
+```
+
+#### `readManifest(files) → object | null`
+
+Returns the manifest from a bundle, or `null` if it has none.
+
+### `runner-io.js`
+
+For features built around code runners. It imports nothing at all.
+
+```js
+import {
+  readRunners, writeRunners, unsavedRunners, listRunners, readRunner
+} from '/assets/js/runner-io.js';
+```
+
+| Function | Returns |
+|---|---|
+| `listRunners()` | every runner element on the page |
+| `unsavedRunners()` | runners whose code has not been saved with 💾 |
+| `readRunner(el)` | one runner's saved code, or `null` |
+| `readRunners(opts?)` | all saved work, as a bundle |
+| `writeRunners(files)` | loads code **into** runners; returns the ids written |
+
+`readRunners()` prepends each challenge prompt so a bundle is readable away from
+the lesson. Pass `{ includeQuestion: false }` for bare code.
+
+`writeRunners()` matches files to runners by id — `main.java` fills the runner
+whose `runner_id` is `main` — and writes to the same key the runner reads from,
+so loaded code survives a refresh exactly like the student's own.
+
+---
+
+## The manifest
+
+Passing `type` adds one small file to every bundle:
+
+```json
+{
+  "type": "portfolio",
+  "version": 1,
+  "source": "/csa/unit-3",
+  "createdAt": "2026-08-17T09:14:22.418Z"
+}
+```
+
+This is what makes a bundle a **format** rather than a pile of files. A consumer
+checks it before doing anything:
+
+```js
+const { files, manifest } = await importFromGist(url);
+if (manifest?.type !== 'portfolio') {
+  throw new Error('That link is not a portfolio.');
+}
+```
+
+Skip the check and a page will happily render a bundle meant for something else.
+
+Use a short, stable name and keep using it: `portfolio`, `starter`,
+`peer-review`, `help-request`, `submission`.
+
+---
+
+## Building a feature
+
+Three steps; only the last is new code.
+
+### 1. Choose where the bundle comes from
+
+If it is code runners, `runner-io.js` already does it. Otherwise write a small
+reader returning the same `{ name: { content } }` shape — and do not let it
+import `gist.js`.
+
+### 2. Choose a type name
+
+One stable string. It is how your bundles are recognised later.
+
+### 3. Write the feature
+
+```js
+// assets/js/portfolio.js
+import { readRunners } from '/assets/js/runner-io.js';
+import { exportToGist, importFromGist } from '/assets/js/gist.js';
+
+const TYPE = 'portfolio';
+
+export async function save() {
+  const files = readRunners();
+  if (!Object.keys(files).length) {
+    throw new Error('Save your work first with the 💾 button.');
+  }
+  return exportToGist(files, { type: TYPE, description: 'Course portfolio' });
+}
+
+export async function load(url) {
+  const { files, manifest } = await importFromGist(url);
+  if (manifest?.type !== TYPE) {
+    throw new Error('That link is not a portfolio.');
+  }
+  return files;
+}
+```
+
+Then surface it on a page:
+
+{% raw %}
+```html
+<!-- _includes/portfolio.html -->
+{% if page.portfolio %}
+  <div id="portfolio-widget">
+    <button id="portfolio-save">Save my work</button>
+    <p id="portfolio-status"></p>
+  </div>
+  <script type="module" src="{{ '/assets/js/portfolio.js' | relative_url }}"></script>
+{% endif %}
+```
+{% endraw %}
+
+And switch it on in a lesson's front matter:
+
+```yaml
+---
+layout: post
+title: My Lesson
+portfolio: true
+---
+```
+
+### Wiring checklist
+
+- Add the include to **both** branches of `_layouts/post.html`. Course lessons and
+  ordinary posts render through different arms of a single condition, and an
+  include added to only one is silently missing on the other.
+- Register any stylesheet as a partial in `_sass/open-coding/` **and** add an
+  `@import` for it in `_main.scss`, or the classes do nothing.
+- Load the script with `type="module"`.
+- Take the backend address from `javaURI` in `assets/js/api/config.js`. Never
+  hardcode a host.
+
+---
+
+## Features built on it
+
+- **Assignment submission** — reads a lesson's runners, bundles the code, and
+  stores the resulting URL against the student's record. The database keeps the
+  record; the bundle keeps the content.
+- **Starter code** *(possible)* — a teacher edits a bundle, and a lesson's runners
+  load from it, so material can change without a site rebuild.
+- **Peer review** *(possible)* — one student shares a bundle and another opens it
+  on their own page.
+- **Portfolio export** *(possible)* — a student takes their whole course with them
+  when they leave.
+
+Each is the same two calls with different answers to *who produces*, *what is in
+it*, and *who opens it*.
+
+---
+
+## Traps
+
+| Trap | Symptom | Fix |
+|---|---|---|
+| Hardcoded backend host | works locally, dead on the live site | import `javaURI` |
+| Plain `<script>` | the whole file silently does nothing | `type="module"` |
+| Include in one layout branch | widget missing on some pages | add to both |
+| Stylesheet not imported | styles have no effect | partial **and** `@import` |
+| No manifest check on import | renders another feature's bundle as garbage | check `manifest.type` |
+| Passing GitHub's response through | leaks detail, breaks on vendor change | return only what is needed |
+| Dev server on an unlisted port | every request fails at CORS, with no clear reason | add the port to **`SecurityConfig`** — it governs `/api/**`, and its list is not the same as `MvcConfig`'s |
+
+Both endpoints are open, and every call spends the organisation's single token.
+That suits an open export tool; if usage grows, requiring a login or capping
+bundle size is the place to start.
+
+---
+
+## Running and verifying locally
+
+```bash
+# backend — .env must exist; GIST_TOKEN must be set for real calls
+cd spring
+python3 scripts/db_init.py     # first run only, creates the local database
+./mvnw spring-boot:run         # serves on 8585
+
+# frontend
+cd pages && make               # serves on 4500
+```
+
+Check in this order, so a failure identifies its own layer:
+
+1. **`curl` the endpoint** — proves the backend, the token, and the security rule.
+2. **The browser** — proves CORS and your page wiring.
+3. **The deployed site** — proves `javaURI` and the server's environment.
+
+Most "it just doesn't work" reports are a layer-one problem discovered at layer
+three.

--- a/assets/js/gist-export-button.js
+++ b/assets/js/gist-export-button.js
@@ -1,3 +1,5 @@
+import { javaURI } from '/assets/js/api/config.js';
+
 (function () {
 
   /* ─────────────────────────────────────────────────────
@@ -392,7 +394,7 @@
       if (!Object.keys(files).length) return;
 
       try {
-        const res = await fetch('http://localhost:8585/api/grades/create-gist', {
+        const res = await fetch(`${javaURI}/api/grades/create-gist`, {
           method: 'POST',
           credentials: 'include',
           headers: { 
@@ -457,7 +459,7 @@
         };
 
         try {
-          const res = await fetch('http://localhost:8585/api/grades', {
+          const res = await fetch(`${javaURI}/api/grades`, {
             method: 'POST', credentials: 'include',
             headers: { 'Content-Type': 'application/json', 'X-Origin': 'client' },
             body: JSON.stringify(payload),

--- a/assets/js/gist-export-button.js
+++ b/assets/js/gist-export-button.js
@@ -1,4 +1,13 @@
+/**
+ * The grading submission widget.
+ *
+ * This file owns the pixel-art UI and the grading flow only. Reading the
+ * runners and creating the envelope are shared modules; this is the one place
+ * that knows about both.
+ */
 import { javaURI } from '/assets/js/api/config.js';
+import { readRunners, unsavedRunners } from '/assets/js/runner-io.js';
+import { exportToGist } from '/assets/js/gist.js';
 
 (function () {
 
@@ -353,13 +362,7 @@ import { javaURI } from '/assets/js/api/config.js';
   async function startExport() {
     if (scrollPhase !== 'idle') return;
 
-    const containers = document.querySelectorAll('.code-runner-container');
-    const unsaved = [...containers].filter(c => {
-      const key = c.dataset.storageKey;
-      return !key || localStorage.getItem(key) === null;
-    });
-
-    if (unsaved.length) {
+    if (unsavedRunners().length) {
       typeDialog(`⚠ Please save your code first using the 💾 button in each runner.`);
       return;
     }
@@ -372,46 +375,16 @@ import { javaURI } from '/assets/js/api/config.js';
     (async () => {
       await new Promise(r => setTimeout(r, 5500));
 
-      const files = {};
-      containers.forEach((container, index) => {
-        const runnerId = container.dataset.runnerId || `runner_${index + 1}`;
-        const challengeBox = container.querySelector('.challenge-box');
-        const challengeTitle = challengeBox?.querySelector('h3')?.textContent.trim() || `Part ${index + 1}`;
-        const challengeDesc  = challengeBox?.querySelector('p')?.textContent.trim() || '';
-        const langSelect = container.querySelector('.languageSelect');
-        const lang = langSelect?.value || 'java';
-        const ext = { python: 'py', java: 'java', javascript: 'js' }[lang] || 'txt';
-
-        const storageKey = container.dataset.storageKey;
-        const code = storageKey ? localStorage.getItem(storageKey)?.trim() : null;
-        if (!code) return;
-
-        const content = `Question: ${challengeTitle}\n${challengeDesc}\n\nAnswer (runner: ${runnerId}):\n\n${code}`;
-        const safeId = runnerId.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
-        files[`${safeId}.${ext}`] = { content };
-      });
-
+      const files = readRunners();
       if (!Object.keys(files).length) return;
 
       try {
-        const res = await fetch(`${javaURI}/api/grades/create-gist`, {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 
-            'Content-Type': 'application/json', 
-            'X-Origin': 'client' 
-          },
-          body: JSON.stringify({
-            files,
-            description: widget.dataset.gistDescription || 'Exported from Open Coding Society'
-          })
+        gistUrl = await exportToGist(files, {
+          type: 'submission',
+          description: widget.dataset.gistDescription,
         });
 
-        if (!res.ok) throw new Error('Gist creation failed');
-
-        const { url } = await res.json();
-        gistUrl = url;
-        await navigator.clipboard.writeText(url);
+        await navigator.clipboard.writeText(gistUrl);
 
         exported = true;
         exportBtn.textContent = '✓ EXPORTED';
@@ -422,7 +395,7 @@ import { javaURI } from '/assets/js/api/config.js';
 
       } catch (e) {
         console.error(e);
-        typeDialog('⚠ Failed to create gist. Try again or contact teacher.');
+        typeDialog(`⚠ ${e.message || 'Failed to create gist. Try again or contact teacher.'}`);
         exportBtn.disabled = false;
         exportBtn.textContent = '✦ EXPORT';
       }

--- a/assets/js/gist.js
+++ b/assets/js/gist.js
@@ -93,10 +93,57 @@ export function readManifest(files) {
   }
 }
 
-/*
- * Note: importFromGist(url) belongs here and is the other half of the envelope,
- * but it needs a backend read endpoint (GET /api/gist/{id}) that does not exist
- * yet. Gists are created as secret, so the browser cannot reliably fetch them
- * from GitHub directly. Shipping a stub that fails at runtime would be worse
- * than leaving the gap visible, so it is deliberately absent.
+/**
+ * Pull the gist id out of anything a person is likely to paste.
+ *
+ * Accepts a bare id, a gist URL with or without a username, and a trailing
+ * revision or /edit segment.
+ *   https://gist.github.com/user/3f7a1b...  -> 3f7a1b...
+ *   https://gist.github.com/3f7a1b...       -> 3f7a1b...
+ *   3f7a1b...                               -> 3f7a1b...
+ *
+ * @param {string} urlOrId
+ * @returns {string|null}
  */
+export function gistIdFrom(urlOrId) {
+  if (!urlOrId) return null;
+  const text = String(urlOrId).trim();
+
+  if (/^[a-fA-F0-9]{6,64}$/.test(text)) return text;
+
+  // Last hex-looking path segment wins; ignores /edit, /revisions, #file-...
+  const segments = text.split(/[/#?]/).filter(Boolean);
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (/^[a-fA-F0-9]{6,64}$/.test(segments[i])) return segments[i];
+  }
+  return null;
+}
+
+/**
+ * Open an envelope: given its URL (or id), get the files back.
+ *
+ * Goes through the backend rather than GitHub directly — gists are created
+ * secret, and the token that can read them lives on the server.
+ *
+ * @param {string} urlOrId
+ * @returns {Promise<{files: Object, description: string, manifest: Object|null}>}
+ */
+export async function importFromGist(urlOrId) {
+  const id = gistIdFrom(urlOrId);
+  if (!id) throw new Error('That does not look like a gist link.');
+
+  const res = await fetch(`${javaURI}/api/grades/read-gist/${id}`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: { 'X-Origin': 'client' },
+  });
+
+  if (!res.ok) {
+    if (res.status === 404) throw new Error('No gist found for that link.');
+    if (res.status === 401 || res.status === 403) throw new Error('Sign in to open this.');
+    throw new Error(`Could not open gist (${res.status})`);
+  }
+
+  const { files, description } = await res.json();
+  return { files: files || {}, description, manifest: readManifest(files) };
+}

--- a/assets/js/gist.js
+++ b/assets/js/gist.js
@@ -1,0 +1,102 @@
+/**
+ * gist.js — the shared envelope.
+ *
+ * Turns a bundle of files into a URL. That is the whole job.
+ *
+ * This module deliberately knows nothing about code runners, grading, lessons
+ * or any widget's markup. Anything that can produce a `files` object can use it,
+ * and it must never import a producer — the feature that needs both is the only
+ * place they meet.
+ *
+ *   import { exportToGist } from '/assets/js/gist.js';
+ *   const url = await exportToGist(files, { type: 'submission' });
+ */
+
+import { javaURI } from '/assets/js/api/config.js';
+
+/** Filename of the manifest describing what an envelope contains. */
+export const MANIFEST = 'ocs.json';
+
+const DEFAULT_DESCRIPTION = 'Exported from Open Coding Society';
+
+/**
+ * Send a bundle of files off and get back a URL pointing at them.
+ *
+ * @param {Object} files  { "name.java": { content: "..." }, ... }
+ * @param {Object} [opts]
+ * @param {string} [opts.type]         what this bundle is, e.g. 'submission'.
+ *                                     Written into the manifest so whoever opens
+ *                                     it can tell whether it is theirs to handle.
+ * @param {string} [opts.description]  human-readable label
+ * @returns {Promise<string>} the URL
+ */
+export async function exportToGist(files, opts = {}) {
+  if (!files || Object.keys(files).length === 0) {
+    throw new Error('exportToGist: no files to send');
+  }
+
+  // Copy, so stamping the manifest never mutates the caller's object.
+  const payload = { ...files };
+
+  if (opts.type) {
+    payload[MANIFEST] = {
+      content: JSON.stringify({
+        type: opts.type,
+        version: 1,
+        source: window.location.pathname,
+        createdAt: new Date().toISOString(),
+      }, null, 2),
+    };
+  }
+
+  const res = await fetch(`${javaURI}/api/grades/create-gist`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Origin': 'client',
+    },
+    body: JSON.stringify({
+      files: payload,
+      description: opts.description || DEFAULT_DESCRIPTION,
+    }),
+  });
+
+  if (!res.ok) {
+    // 401/403 is by far the most common failure and deserves its own message,
+    // otherwise callers surface the literal word "Forbidden" to a student.
+    if (res.status === 401 || res.status === 403) {
+      throw new Error('Sign in before exporting.');
+    }
+    throw new Error(`Export failed (${res.status})`);
+  }
+
+  const { url } = await res.json();
+  if (!url) throw new Error('Export succeeded but returned no URL');
+  return url;
+}
+
+/**
+ * Read the manifest out of a bundle, if it has one.
+ * Lets a consumer check `type` before trying to render someone else's payload.
+ *
+ * @param {Object} files
+ * @returns {Object|null}
+ */
+export function readManifest(files) {
+  const raw = files?.[MANIFEST]?.content;
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/*
+ * Note: importFromGist(url) belongs here and is the other half of the envelope,
+ * but it needs a backend read endpoint (GET /api/gist/{id}) that does not exist
+ * yet. Gists are created as secret, so the browser cannot reliably fetch them
+ * from GitHub directly. Shipping a stub that fails at runtime would be worse
+ * than leaving the gap visible, so it is deliberately absent.
+ */

--- a/assets/js/runner-io.js
+++ b/assets/js/runner-io.js
@@ -1,0 +1,118 @@
+/**
+ * runner-io.js — reading and writing code runners.
+ *
+ * Knows how a runner stores its code on the page; knows nothing about where
+ * that code is going. It must never import gist.js (or any transport) — that
+ * is what lets the same reader feed a gist, an AI grader, or a Slack message
+ * without dragging any of them along.
+ *
+ *   import { readRunners } from '/assets/js/runner-io.js';
+ *   const files = readRunners();
+ */
+
+const RUNNER_SELECTOR = '.code-runner-container';
+
+/** Runner language -> file extension. Unknown languages fall back to .txt */
+const EXTENSIONS = {
+  python: 'py',
+  java: 'java',
+  javascript: 'js',
+  pseudocode: 'txt',
+};
+
+/** Every runner on the page, in document order. */
+export function listRunners() {
+  return [...document.querySelectorAll(RUNNER_SELECTOR)];
+}
+
+/**
+ * Runners whose code has not been saved with the 💾 button.
+ * A runner stores to localStorage under the key it declares in
+ * `data-storage-key`, so "unsaved" means that key holds nothing.
+ */
+export function unsavedRunners() {
+  return listRunners().filter((el) => {
+    const key = el.dataset.storageKey;
+    return !key || localStorage.getItem(key) === null;
+  });
+}
+
+/** The saved code for one runner element, or null. */
+export function readRunner(el) {
+  const key = el.dataset.storageKey;
+  if (!key) return null;
+  return localStorage.getItem(key)?.trim() || null;
+}
+
+/**
+ * Collect every runner's saved work into a files bundle.
+ *
+ * @param {Object} [opts]
+ * @param {boolean} [opts.includeQuestion=true] prepend the challenge prompt so
+ *        the bundle is readable on its own, away from the lesson page.
+ * @returns {Object} { "runner_id.java": { content: "..." }, ... }
+ */
+export function readRunners(opts = {}) {
+  const includeQuestion = opts.includeQuestion !== false;
+  const files = {};
+
+  listRunners().forEach((container, index) => {
+    const code = readRunner(container);
+    if (!code) return;
+
+    const runnerId = container.dataset.runnerId || `runner_${index + 1}`;
+    const lang = container.querySelector('.languageSelect')?.value || 'java';
+    const ext = EXTENSIONS[lang] || 'txt';
+
+    let content = code;
+    if (includeQuestion) {
+      const box = container.querySelector('.challenge-box');
+      const title = box?.querySelector('h3')?.textContent.trim() || `Part ${index + 1}`;
+      const desc = box?.querySelector('p')?.textContent.trim() || '';
+      content = `Question: ${title}\n${desc}\n\nAnswer (runner: ${runnerId}):\n\n${code}`;
+    }
+
+    files[`${safeName(runnerId)}.${ext}`] = { content };
+  });
+
+  return files;
+}
+
+/**
+ * Load code into the runners on this page — the reverse direction, used by
+ * anything that hands a student prepared code (starter files, a peer's
+ * solution). Matches by runner id; unmatched entries are ignored.
+ *
+ * Writes through the same localStorage key the runner reads from, so the code
+ * survives a refresh exactly like the student's own work.
+ *
+ * @param {Object} files bundle keyed by "<runner_id>.<ext>"
+ * @returns {string[]} ids of the runners that were written
+ */
+export function writeRunners(files) {
+  const written = [];
+
+  listRunners().forEach((container, index) => {
+    const runnerId = container.dataset.runnerId || `runner_${index + 1}`;
+    const key = container.dataset.storageKey;
+    if (!key) return;
+
+    const match = Object.keys(files).find(
+      (name) => name.replace(/\.[^.]+$/, '') === safeName(runnerId)
+    );
+    if (!match) return;
+
+    const code = files[match]?.content;
+    if (typeof code !== 'string') return;
+
+    localStorage.setItem(key, code);
+    written.push(runnerId);
+  });
+
+  return written;
+}
+
+/** Runner ids become filenames, so keep them to characters a filename can hold. */
+function safeName(runnerId) {
+  return runnerId.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
+}


### PR DESCRIPTION
Needs the Spring PR first for the read endpoint.

- export never worked on the deployed site: the URL was hardcoded to
  `localhost`, so it called the student's own computer. now uses `javaURI`.
- widget rendered at the top overlapping the lesson: moved it to the bottom.
- split the 491-line file into `gist.js` (sends/gets files) and `runner-io.js`
  (reads/writes runners). neither imports the other, so features can use just one.
- docs at `/gist`.

tested in the browser against backend: saved code → exported → read back →
loaded into runners, all matched. 

needs [spring pr](https://github.com/Open-Coding-Society/spring/pull/166) to merge first